### PR TITLE
[codex] Add Chess.com PubAPI client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,10 @@
         "vitest": "^4.1.5"
       }
     },
+    "node_modules/@chessinsights/chesscom-client": {
+      "resolved": "packages/chesscom-client",
+      "link": true
+    },
     "node_modules/@chessinsights/domain": {
       "resolved": "packages/domain",
       "link": true
@@ -2486,6 +2490,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "packages/chesscom-client": {
+      "name": "@chessinsights/chesscom-client",
+      "version": "0.1.0"
     },
     "packages/domain": {
       "name": "@chessinsights/domain",

--- a/packages/chesscom-client/package.json
+++ b/packages/chesscom-client/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@chessinsights/chesscom-client",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "npm --prefix ../.. run lint",
+    "typecheck": "npm --prefix ../.. run typecheck",
+    "test": "npm --prefix ../.. run test"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}
+

--- a/packages/chesscom-client/src/client.test.ts
+++ b/packages/chesscom-client/src/client.test.ts
@@ -1,0 +1,186 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { createChessComClient } from "./client.js";
+import type { ChessComFetch } from "./types.js";
+
+const fixtureRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../tests/fixtures/chesscom");
+
+function readFixture<TFixture>(fileName: string): TFixture {
+  return JSON.parse(readFileSync(resolve(fixtureRoot, fileName), "utf8")) as TFixture;
+}
+
+interface MockFetchCall {
+  readonly input: string;
+  readonly init: RequestInit | undefined;
+}
+
+function mockFetch(response: Response): { readonly calls: MockFetchCall[]; readonly fetch: ChessComFetch } {
+  const calls: MockFetchCall[] = [];
+
+  return {
+    calls,
+    fetch: async (input, init) => {
+      calls.push({ input, init });
+      return response;
+    }
+  };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      ...init.headers
+    },
+    ...init
+  });
+}
+
+function headerValue(init: RequestInit | undefined, headerName: string): string | null {
+  return new Headers(init?.headers).get(headerName);
+}
+
+describe("Chess.com PubAPI client", () => {
+  it("fetches a player profile from the documented profile endpoint", async () => {
+    const profile = readFixture("profile.json");
+    const { calls, fetch } = mockFetch(
+      jsonResponse(profile, {
+        headers: {
+          "Cache-Control": "public, max-age=43200",
+          ETag: '"profile-etag"',
+          "Last-Modified": "Wed, 01 Jan 2025 00:00:00 GMT"
+        }
+      })
+    );
+    const client = createChessComClient({ fetch, userAgent: "ChessInsightsTest/1.0" });
+
+    const response = await client.getPlayerProfile(" TestUser ");
+
+    expect(response.status).toBe(200);
+    expect(response.data).toMatchObject({
+      username: "TestUser",
+      player_id: 12345
+    });
+    expect(response.metadata).toEqual({
+      url: "https://api.chess.com/pub/player/testuser",
+      etag: '"profile-etag"',
+      lastModified: "Wed, 01 Jan 2025 00:00:00 GMT",
+      cacheControl: "public, max-age=43200",
+      retryAfter: null
+    });
+    expect(calls[0]?.input).toBe("https://api.chess.com/pub/player/testuser");
+    expect(headerValue(calls[0]?.init, "Accept")).toBe("application/json");
+    expect(headerValue(calls[0]?.init, "User-Agent")).toBe("ChessInsightsTest/1.0");
+  });
+
+  it("sends cache validators and returns 304 metadata without parsing JSON", async () => {
+    const { calls, fetch } = mockFetch(
+      new Response(null, {
+        status: 304,
+        headers: {
+          ETag: '"same"',
+          "Last-Modified": "Thu, 02 Jan 2025 00:00:00 GMT"
+        }
+      })
+    );
+    const client = createChessComClient({ fetch });
+
+    const response = await client.getPlayerStats("testuser", {
+      etag: '"same"',
+      lastModified: "Thu, 02 Jan 2025 00:00:00 GMT"
+    });
+
+    expect(response).toMatchObject({
+      status: 304,
+      data: null,
+      metadata: {
+        url: "https://api.chess.com/pub/player/testuser/stats",
+        etag: '"same"',
+        lastModified: "Thu, 02 Jan 2025 00:00:00 GMT"
+      }
+    });
+    expect(headerValue(calls[0]?.init, "If-None-Match")).toBe('"same"');
+    expect(headerValue(calls[0]?.init, "If-Modified-Since")).toBe("Thu, 02 Jan 2025 00:00:00 GMT");
+  });
+
+  it("fetches stats, archives, and monthly game archives from documented paths", async () => {
+    const stats = readFixture("stats.json");
+    const archives = readFixture("archives.json");
+    const monthlyGames = readFixture("monthly-games.json");
+    const calls: MockFetchCall[] = [];
+    const responses = [jsonResponse(stats), jsonResponse(archives), jsonResponse(monthlyGames)];
+    const fetch: ChessComFetch = async (input, init) => {
+      calls.push({ input, init });
+      const response = responses.shift();
+
+      if (response === undefined) {
+        throw new Error("Unexpected extra fetch call");
+      }
+
+      return response;
+    };
+    const client = createChessComClient({ fetch });
+
+    await expect(client.getPlayerStats("TestUser")).resolves.toMatchObject({ status: 200, data: stats });
+    await expect(client.getGameArchives("TestUser")).resolves.toMatchObject({ status: 200, data: archives });
+    await expect(client.getMonthlyGames("TestUser", 2024, 1)).resolves.toMatchObject({
+      status: 200,
+      data: monthlyGames
+    });
+
+    expect(calls.map((call) => call.input)).toEqual([
+      "https://api.chess.com/pub/player/testuser/stats",
+      "https://api.chess.com/pub/player/testuser/games/archives",
+      "https://api.chess.com/pub/player/testuser/games/2024/01"
+    ]);
+  });
+
+  it.each([
+    [404, "not_found"],
+    [410, "gone"],
+    [429, "rate_limited"]
+  ] as const)("throws typed provider errors for %s responses", async (status, kind) => {
+    const { fetch } = mockFetch(
+      new Response(JSON.stringify({ message: "provider error" }), {
+        status,
+        headers: {
+          "Retry-After": "30"
+        }
+      })
+    );
+    const client = createChessComClient({ fetch });
+
+    await expect(client.getGameArchives("testuser")).rejects.toMatchObject({
+      name: "ChessComApiError",
+      status,
+      kind,
+      metadata: {
+        url: "https://api.chess.com/pub/player/testuser/games/archives",
+        retryAfter: "30"
+      }
+    });
+  });
+
+  it("rejects invalid usernames before making provider requests", async () => {
+    const { calls, fetch } = mockFetch(jsonResponse({}));
+    const client = createChessComClient({ fetch });
+
+    await expect(client.getPlayerProfile("../hikaru")).rejects.toThrow(TypeError);
+    await expect(client.getPlayerProfile("name?callback=bad")).rejects.toThrow(TypeError);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("rejects invalid monthly archive dates before making provider requests", async () => {
+    const { calls, fetch } = mockFetch(jsonResponse({}));
+    const client = createChessComClient({ fetch });
+
+    await expect(client.getMonthlyGames("testuser", 2006, 1)).rejects.toThrow(TypeError);
+    await expect(client.getMonthlyGames("testuser", 2024, 13)).rejects.toThrow(TypeError);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/packages/chesscom-client/src/client.test.ts
+++ b/packages/chesscom-client/src/client.test.ts
@@ -31,13 +31,12 @@ function mockFetch(response: Response): { readonly calls: MockFetchCall[]; reado
 }
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  headers.set("Content-Type", "application/json");
+
   return new Response(JSON.stringify(body), {
-    status: 200,
-    headers: {
-      "Content-Type": "application/json",
-      ...init.headers
-    },
-    ...init
+    ...init,
+    headers
   });
 }
 
@@ -141,6 +140,7 @@ describe("Chess.com PubAPI client", () => {
   });
 
   it.each([
+    [303, "redirect"],
     [404, "not_found"],
     [410, "gone"],
     [429, "rate_limited"]

--- a/packages/chesscom-client/src/client.ts
+++ b/packages/chesscom-client/src/client.ts
@@ -124,7 +124,7 @@ function readResponseMetadata(url: string, response: Response): ProviderResponse
 }
 
 function classifyErrorStatus(status: number): ProviderErrorKind {
-  if (status === 301 || status === 302 || status === 307 || status === 308) {
+  if (status === 301 || status === 302 || status === 303 || status === 307 || status === 308) {
     return "redirect";
   }
 

--- a/packages/chesscom-client/src/client.ts
+++ b/packages/chesscom-client/src/client.ts
@@ -1,0 +1,148 @@
+import { ChessComApiError } from "./errors.js";
+import { formatArchiveMonth, formatArchiveYear, normalizeChessComUsername } from "./validation.js";
+import type {
+  CacheValidators,
+  ChessComArchives,
+  ChessComClientOptions,
+  ChessComFetch,
+  ChessComMonthlyGames,
+  ChessComProfile,
+  ChessComStats,
+  ProviderErrorKind,
+  ProviderResponse,
+  ProviderResponseMetadata
+} from "./types.js";
+
+const CHESS_COM_API_ORIGIN = "https://api.chess.com";
+const DEFAULT_USER_AGENT = "ChessInsights/0.1 (+https://github.com/invinoverita5/SeeMore)";
+
+export interface ChessComClient {
+  getPlayerProfile(username: string, validators?: CacheValidators): Promise<ProviderResponse<ChessComProfile>>;
+  getPlayerStats(username: string, validators?: CacheValidators): Promise<ProviderResponse<ChessComStats>>;
+  getGameArchives(username: string, validators?: CacheValidators): Promise<ProviderResponse<ChessComArchives>>;
+  getMonthlyGames(
+    username: string,
+    year: number,
+    month: number,
+    validators?: CacheValidators
+  ): Promise<ProviderResponse<ChessComMonthlyGames>>;
+}
+
+export function createChessComClient(options: ChessComClientOptions = {}): ChessComClient {
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+
+  if (fetchImpl === undefined) {
+    throw new TypeError("A fetch implementation is required to create the Chess.com client.");
+  }
+
+  const userAgent = options.userAgent ?? DEFAULT_USER_AGENT;
+
+  return {
+    async getPlayerProfile(username, validators) {
+      return requestJson<ChessComProfile>(fetchImpl, userAgent, playerPath(username), validators);
+    },
+    async getPlayerStats(username, validators) {
+      return requestJson<ChessComStats>(fetchImpl, userAgent, `${playerPath(username)}/stats`, validators);
+    },
+    async getGameArchives(username, validators) {
+      return requestJson<ChessComArchives>(fetchImpl, userAgent, `${playerPath(username)}/games/archives`, validators);
+    },
+    async getMonthlyGames(username, year, month, validators) {
+      const normalizedUsername = normalizeChessComUsername(username);
+      const archiveYear = formatArchiveYear(year);
+      const archiveMonth = formatArchiveMonth(month);
+      return requestJson<ChessComMonthlyGames>(
+        fetchImpl,
+        userAgent,
+        `/pub/player/${normalizedUsername}/games/${archiveYear}/${archiveMonth}`,
+        validators
+      );
+    }
+  };
+}
+
+function playerPath(username: string): string {
+  return `/pub/player/${normalizeChessComUsername(username)}`;
+}
+
+async function requestJson<TData>(
+  fetchImpl: ChessComFetch,
+  userAgent: string,
+  path: string,
+  validators?: CacheValidators
+): Promise<ProviderResponse<TData>> {
+  const url = new URL(path, CHESS_COM_API_ORIGIN);
+  const response = await fetchImpl(url.href, {
+    headers: buildHeaders(userAgent, validators)
+  });
+  const metadata = readResponseMetadata(url.href, response);
+
+  if (response.status === 304) {
+    return {
+      status: 304,
+      data: null,
+      metadata
+    };
+  }
+
+  if (response.status !== 200) {
+    throw new ChessComApiError(classifyErrorStatus(response.status), response.status, metadata);
+  }
+
+  return {
+    status: 200,
+    data: (await response.json()) as TData,
+    metadata
+  };
+}
+
+function buildHeaders(userAgent: string, validators?: CacheValidators): Headers {
+  const headers = new Headers({
+    Accept: "application/json",
+    "User-Agent": userAgent
+  });
+
+  if (validators?.etag !== undefined) {
+    headers.set("If-None-Match", validators.etag);
+  }
+
+  if (validators?.lastModified !== undefined) {
+    headers.set("If-Modified-Since", validators.lastModified);
+  }
+
+  return headers;
+}
+
+function readResponseMetadata(url: string, response: Response): ProviderResponseMetadata {
+  return {
+    url,
+    etag: response.headers.get("ETag"),
+    lastModified: response.headers.get("Last-Modified"),
+    cacheControl: response.headers.get("Cache-Control"),
+    retryAfter: response.headers.get("Retry-After")
+  };
+}
+
+function classifyErrorStatus(status: number): ProviderErrorKind {
+  if (status === 301 || status === 302 || status === 307 || status === 308) {
+    return "redirect";
+  }
+
+  if (status === 404) {
+    return "not_found";
+  }
+
+  if (status === 410) {
+    return "gone";
+  }
+
+  if (status === 429) {
+    return "rate_limited";
+  }
+
+  if (status >= 500) {
+    return "server_error";
+  }
+
+  return "unexpected_status";
+}

--- a/packages/chesscom-client/src/errors.ts
+++ b/packages/chesscom-client/src/errors.ts
@@ -1,0 +1,16 @@
+import type { ProviderErrorKind, ProviderResponseMetadata } from "./types.js";
+
+export class ChessComApiError extends Error {
+  readonly kind: ProviderErrorKind;
+  readonly status: number;
+  readonly metadata: ProviderResponseMetadata;
+
+  constructor(kind: ProviderErrorKind, status: number, metadata: ProviderResponseMetadata) {
+    super(`Chess.com PubAPI request failed with ${status} (${kind})`);
+    this.name = "ChessComApiError";
+    this.kind = kind;
+    this.status = status;
+    this.metadata = metadata;
+  }
+}
+

--- a/packages/chesscom-client/src/index.ts
+++ b/packages/chesscom-client/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./client.js";
+export * from "./errors.js";
+export * from "./types.js";
+export * from "./validation.js";
+

--- a/packages/chesscom-client/src/types.ts
+++ b/packages/chesscom-client/src/types.ts
@@ -1,0 +1,89 @@
+export type ChessComFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+export type ProviderStatus = 200 | 304;
+
+export type ProviderErrorKind =
+  | "gone"
+  | "not_found"
+  | "rate_limited"
+  | "redirect"
+  | "server_error"
+  | "unexpected_status";
+
+export interface ChessComClientOptions {
+  readonly fetch?: ChessComFetch;
+  readonly userAgent?: string;
+}
+
+export interface CacheValidators {
+  readonly etag?: string;
+  readonly lastModified?: string;
+}
+
+export interface ProviderResponseMetadata {
+  readonly url: string;
+  readonly etag: string | null;
+  readonly lastModified: string | null;
+  readonly cacheControl: string | null;
+  readonly retryAfter: string | null;
+}
+
+export interface ProviderResponse<TData> {
+  readonly status: ProviderStatus;
+  readonly data: TData | null;
+  readonly metadata: ProviderResponseMetadata;
+}
+
+export interface ChessComProfile {
+  readonly "@id": string;
+  readonly url: string;
+  readonly username: string;
+  readonly player_id: number;
+  readonly title?: string;
+  readonly status?: string;
+  readonly name?: string;
+  readonly avatar?: string;
+  readonly location?: string;
+  readonly country?: string;
+  readonly joined?: number;
+  readonly last_online?: number;
+  readonly followers?: number;
+  readonly is_streamer?: boolean;
+  readonly twitch_url?: string;
+  readonly fide?: number;
+}
+
+export interface ChessComStats {
+  readonly [key: string]: unknown;
+}
+
+export interface ChessComArchives {
+  readonly archives: string[];
+}
+
+export interface ChessComSide {
+  readonly username: string;
+  readonly rating?: number;
+  readonly result: string;
+  readonly "@id"?: string;
+  readonly uuid?: string;
+}
+
+export interface ChessComGame {
+  readonly url: string;
+  readonly pgn: string;
+  readonly time_control?: string;
+  readonly end_time?: number;
+  readonly rated?: boolean;
+  readonly time_class?: string;
+  readonly rules?: string;
+  readonly eco?: string;
+  readonly white: ChessComSide;
+  readonly black: ChessComSide;
+  readonly [key: string]: unknown;
+}
+
+export interface ChessComMonthlyGames {
+  readonly games: ChessComGame[];
+}
+

--- a/packages/chesscom-client/src/validation.ts
+++ b/packages/chesscom-client/src/validation.ts
@@ -1,0 +1,29 @@
+const CHESS_COM_USERNAME_PATTERN = /^[a-z0-9_-]{1,50}$/;
+const MIN_ARCHIVE_YEAR = 2007;
+
+export function normalizeChessComUsername(username: string): string {
+  const normalizedUsername = username.trim().toLowerCase();
+
+  if (!CHESS_COM_USERNAME_PATTERN.test(normalizedUsername)) {
+    throw new TypeError("Chess.com username must be 1-50 characters using letters, numbers, underscores, or hyphens.");
+  }
+
+  return normalizedUsername;
+}
+
+export function formatArchiveYear(year: number): string {
+  if (!Number.isInteger(year) || year < MIN_ARCHIVE_YEAR || year > 9999) {
+    throw new TypeError(`Chess.com archive year must be an integer between ${MIN_ARCHIVE_YEAR} and 9999.`);
+  }
+
+  return String(year).padStart(4, "0");
+}
+
+export function formatArchiveMonth(month: number): string {
+  if (!Number.isInteger(month) || month < 1 || month > 12) {
+    throw new TypeError("Chess.com archive month must be an integer from 1 to 12.");
+  }
+
+  return String(month).padStart(2, "0");
+}
+

--- a/tests/fixtures/chesscom/archives.json
+++ b/tests/fixtures/chesscom/archives.json
@@ -1,0 +1,6 @@
+{
+  "archives": [
+    "https://api.chess.com/pub/player/testuser/games/2024/01",
+    "https://api.chess.com/pub/player/testuser/games/2024/02"
+  ]
+}

--- a/tests/fixtures/chesscom/profile.json
+++ b/tests/fixtures/chesscom/profile.json
@@ -1,0 +1,12 @@
+{
+  "@id": "https://api.chess.com/pub/player/testuser",
+  "url": "https://www.chess.com/member/TestUser",
+  "username": "TestUser",
+  "player_id": 12345,
+  "status": "premium",
+  "country": "https://api.chess.com/pub/country/US",
+  "joined": 1609459200,
+  "last_online": 1705307200,
+  "followers": 42
+}
+

--- a/tests/fixtures/chesscom/stats.json
+++ b/tests/fixtures/chesscom/stats.json
@@ -1,0 +1,27 @@
+{
+  "chess_blitz": {
+    "last": {
+      "rating": 1350,
+      "date": 1705307200,
+      "rd": 50
+    },
+    "record": {
+      "win": 120,
+      "loss": 100,
+      "draw": 15
+    }
+  },
+  "chess_rapid": {
+    "last": {
+      "rating": 1402,
+      "date": 1705430651,
+      "rd": 44
+    },
+    "record": {
+      "win": 60,
+      "loss": 45,
+      "draw": 12
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary

Adds a focused `@chessinsights/chesscom-client` package for documented Chess.com PubAPI reads. The client builds only fixed `https://api.chess.com` public endpoint paths, supports injected `fetch` for tests, preserves cache/retry metadata, and exposes typed provider errors for key HTTP statuses.

Closes #4.

Reference: Chess.com Published-Data API docs: https://www.chess.com/news/view/published-data-api

## Changed files

- `packages/chesscom-client/package.json`: workspace package metadata and CI scripts.
- `packages/chesscom-client/src/client.ts`: profile, stats, archive-list, and monthly-games request methods.
- `packages/chesscom-client/src/types.ts`: provider response, metadata, profile, stats, archive, and game types.
- `packages/chesscom-client/src/errors.ts`: typed `ChessComApiError`.
- `packages/chesscom-client/src/validation.ts`: username and archive date validation.
- `packages/chesscom-client/src/client.test.ts`: mocked-response tests with no live provider calls.
- `tests/fixtures/chesscom/profile.json`, `stats.json`, `archives.json`: compact public-shape fixtures.
- `package-lock.json`: workspace link for the new package.

## Validation

- [x] Relevant tests run
- [x] Lint ran, if applicable
- [x] Typecheck ran, if applicable
- [ ] Build ran for user-visible web changes, if applicable
- [x] Behavior changes include or update regression tests
- [x] PR summary explains changed files and test results

Commands run:

```text
npm install
npm run lint
npm run typecheck
npm run test
git diff --check
npm run lint -w @chessinsights/chesscom-client
npm run typecheck -w @chessinsights/chesscom-client
npm run test -w @chessinsights/chesscom-client
```

Commands not run / reason:

```text
npm run build - no build script or user-visible web app exists yet.
Live Chess.com calls - intentionally not run; tests use injected fetch and fixtures only.
```

## Risk / rollout

- [x] No provider, scraper, queue, or rate-limit behavior changed
- [x] No database schema or migration changed
- [x] No user-visible behavior changed
- [x] Rollback or follow-up plan is documented below, if needed

Notes:

This PR adds the provider client boundary only. It does not add retries, parallel fetching, background jobs, persistence, or dashboard behavior. Provider metadata (`ETag`, `Last-Modified`, `Cache-Control`, and `Retry-After`) is preserved for later cache/retry work.

Follow-up work: add an import worker/service that serializes archive fetches per username and persists raw monthly payloads.

## CodeRabbit follow-up

Addressed actionable CodeRabbit comments by:

- Fixing the JSON response test helper so `Content-Type: application/json` is preserved when custom response headers are present.
- Classifying HTTP 303 as `redirect` and adding a regression case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a Chess.com API client package.
  * Fetch player profiles, stats, game archives, and monthly games.
  * Support for HTTP caching via ETag and Last-Modified (conditional requests).
  * Typed, descriptive error responses including retry timing and metadata.
  * Input validation for usernames, years, and months.

* **Tests**
  * Added comprehensive test suite and fixtures covering client behavior and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->