### PR TITLE
[codex] Add Chess.com import service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,10 @@
       "resolved": "packages/domain",
       "link": true
     },
+    "node_modules/@chessinsights/importer": {
+      "resolved": "packages/importer",
+      "link": true
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -2498,6 +2502,14 @@
     "packages/domain": {
       "name": "@chessinsights/domain",
       "version": "0.1.0"
+    },
+    "packages/importer": {
+      "name": "@chessinsights/importer",
+      "version": "0.1.0",
+      "dependencies": {
+        "@chessinsights/chesscom-client": "file:../chesscom-client",
+        "@chessinsights/domain": "file:../domain"
+      }
     }
   }
 }

--- a/packages/importer/package.json
+++ b/packages/importer/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@chessinsights/importer",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "npm --prefix ../.. run lint",
+    "typecheck": "npm --prefix ../.. run typecheck",
+    "test": "npm --prefix ../.. run test"
+  },
+  "dependencies": {
+    "@chessinsights/chesscom-client": "file:../chesscom-client",
+    "@chessinsights/domain": "file:../domain"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}
+

--- a/packages/importer/src/archive-url.test.ts
+++ b/packages/importer/src/archive-url.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { parseMonthlyArchiveUrl, parseMonthlyArchiveUrls } from "./archive-url.js";
+
+describe("archive URL parsing", () => {
+  it("parses documented Chess.com monthly archive URLs", () => {
+    expect(parseMonthlyArchiveUrl("https://api.chess.com/pub/player/TestUser/games/2024/01", "testuser")).toEqual({
+      url: "https://api.chess.com/pub/player/TestUser/games/2024/01",
+      year: 2024,
+      month: 1
+    });
+  });
+
+  it.each([
+    "https://example.com/pub/player/testuser/games/2024/01",
+    "https://api.chess.com/pub/player/otheruser/games/2024/01",
+    "https://api.chess.com/pub/player/testuser/games/2006/01",
+    "https://api.chess.com/pub/player/testuser/games/2024/13",
+    "https://api.chess.com/pub/player/testuser",
+    "not a url"
+  ])("rejects unsupported archive URL %s", (archiveUrl) => {
+    expect(parseMonthlyArchiveUrl(archiveUrl, "testuser")).toBeNull();
+  });
+
+  it("preserves listed archive order while skipping malformed URLs and duplicate months", () => {
+    const parsed = parseMonthlyArchiveUrls(
+      [
+        "https://api.chess.com/pub/player/testuser/games/2024/02",
+        "https://api.chess.com/pub/player/testuser/games/2024/01",
+        "https://api.chess.com/pub/player/testuser/games/2024/01",
+        "https://example.com/pub/player/testuser/games/2024/03"
+      ],
+      "testuser"
+    );
+
+    expect(parsed.archiveMonths).toEqual([
+      {
+        url: "https://api.chess.com/pub/player/testuser/games/2024/02",
+        year: 2024,
+        month: 2
+      },
+      {
+        url: "https://api.chess.com/pub/player/testuser/games/2024/01",
+        year: 2024,
+        month: 1
+      }
+    ]);
+    expect(parsed.skippedArchiveUrls).toEqual(["https://example.com/pub/player/testuser/games/2024/03"]);
+  });
+});

--- a/packages/importer/src/archive-url.ts
+++ b/packages/importer/src/archive-url.ts
@@ -1,0 +1,84 @@
+import { formatArchiveMonth, formatArchiveYear, normalizeChessComUsername } from "@chessinsights/chesscom-client";
+
+import type { ImportArchiveMonth } from "./types.js";
+
+const CHESS_COM_API_ORIGIN = "https://api.chess.com";
+
+export function parseMonthlyArchiveUrl(url: string, username: string): ImportArchiveMonth | null {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return null;
+  }
+
+  if (parsedUrl.origin !== CHESS_COM_API_ORIGIN) {
+    return null;
+  }
+
+  const expectedUsername = normalizeChessComUsername(username);
+  const segments = parsedUrl.pathname.split("/").filter(Boolean);
+
+  if (
+    segments.length !== 6 ||
+    segments[0] !== "pub" ||
+    segments[1] !== "player" ||
+    segments[2]?.toLowerCase() !== expectedUsername ||
+    segments[3] !== "games"
+  ) {
+    return null;
+  }
+
+  const year = Number(segments[4]);
+  const month = Number(segments[5]);
+
+  if (!Number.isInteger(year) || !Number.isInteger(month)) {
+    return null;
+  }
+
+  try {
+    formatArchiveYear(year);
+    formatArchiveMonth(month);
+  } catch {
+    return null;
+  }
+
+  return {
+    url: parsedUrl.href,
+    year,
+    month
+  };
+}
+
+export function parseMonthlyArchiveUrls(
+  archiveUrls: readonly string[],
+  username: string
+): { readonly archiveMonths: ImportArchiveMonth[]; readonly skippedArchiveUrls: string[] } {
+  const archiveMonths: ImportArchiveMonth[] = [];
+  const skippedArchiveUrls: string[] = [];
+  const seenArchiveKeys = new Set<string>();
+
+  for (const archiveUrl of archiveUrls) {
+    const archiveMonth = parseMonthlyArchiveUrl(archiveUrl, username);
+
+    if (archiveMonth === null) {
+      skippedArchiveUrls.push(archiveUrl);
+      continue;
+    }
+
+    const archiveKey = `${archiveMonth.year}-${archiveMonth.month}`;
+
+    if (seenArchiveKeys.has(archiveKey)) {
+      continue;
+    }
+
+    seenArchiveKeys.add(archiveKey);
+    archiveMonths.push(archiveMonth);
+  }
+
+  return {
+    archiveMonths,
+    skippedArchiveUrls
+  };
+}

--- a/packages/importer/src/import-player.test.ts
+++ b/packages/importer/src/import-player.test.ts
@@ -1,0 +1,141 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type {
+  ChessComArchives,
+  ChessComMonthlyGames,
+  ChessComProfile,
+  ChessComStats,
+  ProviderResponse,
+  ProviderResponseMetadata
+} from "@chessinsights/chesscom-client";
+import { describe, expect, it } from "vitest";
+
+import { importChessComPlayer } from "./import-player.js";
+import type { ChessComImportClient, ImportProgressEvent } from "./types.js";
+
+const fixtureRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../tests/fixtures/chesscom");
+
+function readFixture<TFixture>(fileName: string): TFixture {
+  return JSON.parse(readFileSync(resolve(fixtureRoot, fileName), "utf8")) as TFixture;
+}
+
+function metadata(url: string): ProviderResponseMetadata {
+  return {
+    url,
+    etag: null,
+    lastModified: null,
+    cacheControl: null,
+    retryAfter: null
+  };
+}
+
+function providerResponse<TData>(url: string, data: TData): ProviderResponse<TData> {
+  return {
+    status: 200,
+    data,
+    metadata: metadata(url)
+  };
+}
+
+interface MockImportClient extends ChessComImportClient {
+  readonly calls: string[];
+}
+
+function createMockClient(): MockImportClient {
+  const profile = readFixture<ChessComProfile>("profile.json");
+  const stats = readFixture<ChessComStats>("stats.json");
+  const monthlyGames = readFixture<ChessComMonthlyGames>("monthly-games.json");
+  const emptyMonthlyGames: ChessComMonthlyGames = {
+    games: []
+  };
+  const archives: ChessComArchives = {
+    archives: [
+      "https://api.chess.com/pub/player/testuser/games/2024/01",
+      "https://api.chess.com/pub/player/testuser/games/2024/02",
+      "https://api.chess.com/pub/player/otheruser/games/2024/03"
+    ]
+  };
+  const calls: string[] = [];
+
+  return {
+    calls,
+    async getPlayerProfile(username) {
+      calls.push(`profile:${username}`);
+      return providerResponse(`https://api.chess.com/pub/player/${username}`, profile);
+    },
+    async getPlayerStats(username) {
+      calls.push(`stats:${username}`);
+      return providerResponse(`https://api.chess.com/pub/player/${username}/stats`, stats);
+    },
+    async getGameArchives(username) {
+      calls.push(`archives:${username}`);
+      return providerResponse(`https://api.chess.com/pub/player/${username}/games/archives`, archives);
+    },
+    async getMonthlyGames(username, year, month) {
+      calls.push(`monthly:${username}:${year}:${month}`);
+      const games = month === 1 ? monthlyGames : emptyMonthlyGames;
+      return providerResponse(`https://api.chess.com/pub/player/${username}/games/${year}/${month}`, games);
+    }
+  };
+}
+
+describe("importChessComPlayer", () => {
+  it("fetches player data and monthly archives sequentially before normalizing supported games", async () => {
+    const client = createMockClient();
+    const events: ImportProgressEvent[] = [];
+
+    const result = await importChessComPlayer(client, " TestUser ", {
+      onProgress(event) {
+        events.push(event);
+      }
+    });
+
+    expect(client.calls).toEqual([
+      "profile:testuser",
+      "stats:testuser",
+      "archives:testuser",
+      "monthly:testuser:2024:1",
+      "monthly:testuser:2024:2"
+    ]);
+    expect(result.username).toBe("testuser");
+    expect(result.profile.username).toBe("TestUser");
+    expect(result.archives).toHaveLength(2);
+    expect(result.archives.map((archive) => `${archive.year}-${archive.month}:${archive.gameCount}`)).toEqual([
+      "2024-1:4",
+      "2024-2:0"
+    ]);
+    expect(result.records).toHaveLength(3);
+    expect(result.skippedGames).toBe(1);
+    expect(result.skippedArchiveUrls).toEqual(["https://api.chess.com/pub/player/otheruser/games/2024/03"]);
+    expect(result.records.map((record) => record.gameUrl)).toEqual([
+      "https://www.chess.com/game/live/1001",
+      "https://www.chess.com/game/live/1002",
+      "https://www.chess.com/game/daily/1003"
+    ]);
+    expect(events.map((event) => event.type)).toEqual([
+      "import_started",
+      "profile_fetched",
+      "stats_fetched",
+      "archives_listed",
+      "archive_fetched",
+      "archive_fetched",
+      "import_completed"
+    ]);
+  });
+
+  it("throws when a required provider response has no data", async () => {
+    const client = createMockClient();
+    client.getPlayerProfile = async () => ({
+      status: 304,
+      data: null,
+      metadata: metadata("https://api.chess.com/pub/player/testuser")
+    });
+
+    await expect(importChessComPlayer(client, "testuser")).rejects.toThrow(
+      "Chess.com profile response did not include data."
+    );
+  });
+});
+

--- a/packages/importer/src/import-player.ts
+++ b/packages/importer/src/import-player.ts
@@ -1,0 +1,121 @@
+import {
+  type ChessComArchives,
+  type ChessComMonthlyGames,
+  type ChessComProfile,
+  type ChessComStats,
+  normalizeChessComUsername,
+  type ProviderResponse
+} from "@chessinsights/chesscom-client";
+import { normalizeChessComGame } from "@chessinsights/domain";
+
+import { parseMonthlyArchiveUrls } from "./archive-url.js";
+import type { ChessComImportClient, ChessComImportResult, ImportOptions, ImportedArchive } from "./types.js";
+
+export async function importChessComPlayer(
+  client: ChessComImportClient,
+  username: string,
+  options: ImportOptions = {}
+): Promise<ChessComImportResult> {
+  const normalizedUsername = normalizeChessComUsername(username);
+  options.onProgress?.({
+    type: "import_started",
+    username: normalizedUsername
+  });
+
+  const profileResponse = await client.getPlayerProfile(normalizedUsername);
+  const profile = requireProviderData(profileResponse, "profile");
+  options.onProgress?.({
+    type: "profile_fetched",
+    username: normalizedUsername,
+    metadata: profileResponse.metadata
+  });
+
+  const statsResponse = await client.getPlayerStats(normalizedUsername);
+  const stats = requireProviderData(statsResponse, "stats");
+  options.onProgress?.({
+    type: "stats_fetched",
+    username: normalizedUsername,
+    metadata: statsResponse.metadata
+  });
+
+  const archivesResponse = await client.getGameArchives(normalizedUsername);
+  const archives = requireProviderData(archivesResponse, "archives");
+  const { archiveMonths, skippedArchiveUrls } = parseMonthlyArchiveUrls(archives.archives, normalizedUsername);
+  options.onProgress?.({
+    type: "archives_listed",
+    username: normalizedUsername,
+    archiveCount: archiveMonths.length,
+    skippedArchiveCount: skippedArchiveUrls.length,
+    metadata: archivesResponse.metadata
+  });
+
+  const importedArchives: ImportedArchive[] = [];
+  const records: ChessComImportResult["records"] = [];
+  let skippedGames = 0;
+
+  for (const archiveMonth of archiveMonths) {
+    const monthlyResponse = await client.getMonthlyGames(normalizedUsername, archiveMonth.year, archiveMonth.month);
+    const monthlyGames = requireProviderData(monthlyResponse, "monthly games");
+
+    importedArchives.push({
+      url: archiveMonth.url,
+      year: archiveMonth.year,
+      month: archiveMonth.month,
+      gameCount: monthlyGames.games.length,
+      metadata: monthlyResponse.metadata
+    });
+
+    options.onProgress?.({
+      type: "archive_fetched",
+      username: normalizedUsername,
+      year: archiveMonth.year,
+      month: archiveMonth.month,
+      gameCount: monthlyGames.games.length,
+      metadata: monthlyResponse.metadata
+    });
+
+    for (const game of monthlyGames.games) {
+      const record = normalizeChessComGame(game, normalizedUsername);
+
+      if (record === null) {
+        skippedGames += 1;
+        continue;
+      }
+
+      records.push(record);
+    }
+  }
+
+  options.onProgress?.({
+    type: "import_completed",
+    username: normalizedUsername,
+    archiveCount: importedArchives.length,
+    recordCount: records.length,
+    skippedGames
+  });
+
+  return {
+    username: normalizedUsername,
+    profile,
+    stats,
+    archivesResponse: archives,
+    archives: importedArchives,
+    records,
+    skippedGames,
+    skippedArchiveUrls
+  };
+}
+
+function requireProviderData<TData>(
+  response: ProviderResponse<TData>,
+  label: "archives" | "monthly games" | "profile" | "stats"
+): TData {
+  if (response.data === null) {
+    throw new Error(`Chess.com ${label} response did not include data.`);
+  }
+
+  return response.data;
+}
+
+export type { ChessComArchives, ChessComMonthlyGames, ChessComProfile, ChessComStats };
+

--- a/packages/importer/src/index.ts
+++ b/packages/importer/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./archive-url.js";
+export * from "./import-player.js";
+export * from "./types.js";
+

--- a/packages/importer/src/types.ts
+++ b/packages/importer/src/types.ts
@@ -1,0 +1,84 @@
+import type {
+  ChessComArchives,
+  ChessComClient,
+  ChessComMonthlyGames,
+  ChessComProfile,
+  ChessComStats,
+  ProviderResponseMetadata
+} from "@chessinsights/chesscom-client";
+import type { NormalizedGameRecord } from "@chessinsights/domain";
+
+export type ChessComImportClient = Pick<
+  ChessComClient,
+  "getGameArchives" | "getMonthlyGames" | "getPlayerProfile" | "getPlayerStats"
+>;
+
+export interface ImportArchiveMonth {
+  readonly url: string;
+  readonly year: number;
+  readonly month: number;
+}
+
+export interface ImportedArchive {
+  readonly url: string;
+  readonly year: number;
+  readonly month: number;
+  readonly gameCount: number;
+  readonly metadata: ProviderResponseMetadata;
+}
+
+export interface ChessComImportResult {
+  readonly username: string;
+  readonly profile: ChessComProfile;
+  readonly stats: ChessComStats;
+  readonly archivesResponse: ChessComArchives;
+  readonly archives: ImportedArchive[];
+  readonly records: NormalizedGameRecord[];
+  readonly skippedGames: number;
+  readonly skippedArchiveUrls: string[];
+}
+
+export type ImportProgressEvent =
+  | {
+      readonly type: "import_started";
+      readonly username: string;
+    }
+  | {
+      readonly type: "profile_fetched";
+      readonly username: string;
+      readonly metadata: ProviderResponseMetadata;
+    }
+  | {
+      readonly type: "stats_fetched";
+      readonly username: string;
+      readonly metadata: ProviderResponseMetadata;
+    }
+  | {
+      readonly type: "archives_listed";
+      readonly username: string;
+      readonly archiveCount: number;
+      readonly skippedArchiveCount: number;
+      readonly metadata: ProviderResponseMetadata;
+    }
+  | {
+      readonly type: "archive_fetched";
+      readonly username: string;
+      readonly year: number;
+      readonly month: number;
+      readonly gameCount: number;
+      readonly metadata: ProviderResponseMetadata;
+    }
+  | {
+      readonly type: "import_completed";
+      readonly username: string;
+      readonly archiveCount: number;
+      readonly recordCount: number;
+      readonly skippedGames: number;
+    };
+
+export interface ImportOptions {
+  readonly onProgress?: (event: ImportProgressEvent) => void;
+}
+
+export type MonthlyGamesResponse = ChessComMonthlyGames;
+


### PR DESCRIPTION
## Summary

Adds `@chessinsights/importer`, a small import service that composes the Chess.com PubAPI client with the domain normalizer. It fetches profile, stats, archive list, and monthly archives sequentially, parses only documented monthly archive URLs, skips malformed archive URLs, filters unsupported games through the normalizer, and returns normalized records plus import metadata.

Closes #6.

## Changed files

- `packages/importer/package.json`: workspace package metadata and internal package dependencies.
- `packages/importer/src/archive-url.ts`: monthly archive URL parsing and validation.
- `packages/importer/src/import-player.ts`: sequential import orchestration and normalization.
- `packages/importer/src/types.ts`: import result, archive, client, and progress-event types.
- `packages/importer/src/*.test.ts`: fixture/mock-backed tests for URL parsing and import flow.
- `package-lock.json`: workspace link and internal package dependency metadata.

## Validation

- [x] Relevant tests run
- [x] Lint ran, if applicable
- [x] Typecheck ran, if applicable
- [ ] Build ran for user-visible web changes, if applicable
- [x] Behavior changes include or update regression tests
- [x] PR summary explains changed files and test results

Commands run:

```text
npm install
npm run lint
npm run typecheck
npm run test
git diff --check
npm run lint -w @chessinsights/importer
npm run typecheck -w @chessinsights/importer
npm run test -w @chessinsights/importer
```

Commands not run / reason:

```text
npm run build - no build script or user-visible web app exists yet.
Live Chess.com calls - intentionally not run; importer tests use mocked client responses and local fixtures only.
```

## Risk / rollout

- [ ] No provider, scraper, queue, or rate-limit behavior changed
- [x] No database schema or migration changed
- [x] No user-visible behavior changed
- [x] Rollback or follow-up plan is documented below, if needed

Notes:

This PR changes provider-adjacent import behavior by adding an orchestration package, but it does not add live calls, retry/backoff behavior, parallel fetching, queue workers, persistence, or public routes. The importer intentionally fetches monthly archives sequentially for one username. Malformed or cross-user archive URLs are skipped rather than fetched.

Follow-up work: add persistence for raw monthly payloads and normalized game records, then layer queue/retry behavior around this service.

## CodeRabbit follow-up

No CodeRabbit follow-up yet; this is the initial PR for issue #6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Chess.com player import functionality to fetch, validate, and normalize game records from monthly archives
  * Added archive URL parsing with automatic deduplication and validation of Chess.com API URLs
  * Implemented progress event tracking throughout the import lifecycle with detailed milestone notifications
  * Includes comprehensive error handling, username normalization, and rejection of unsupported archive URLs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->