### PR TITLE
[codex] Add analytics aggregations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,10 @@
         "vitest": "^4.1.5"
       }
     },
+    "node_modules/@chessinsights/analytics": {
+      "resolved": "packages/analytics",
+      "link": true
+    },
     "node_modules/@chessinsights/chesscom-client": {
       "resolved": "packages/chesscom-client",
       "link": true
@@ -2493,6 +2497,13 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/analytics": {
+      "name": "@chessinsights/analytics",
+      "version": "0.1.0",
+      "dependencies": {
+        "@chessinsights/domain": "file:../domain"
       }
     },
     "packages/chesscom-client": {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@chessinsights/analytics",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "npm --prefix ../.. run lint",
+    "typecheck": "npm --prefix ../.. run typecheck",
+    "test": "npm --prefix ../.. run test"
+  },
+  "dependencies": {
+    "@chessinsights/domain": "file:../domain"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}
+

--- a/packages/analytics/src/analytics.test.ts
+++ b/packages/analytics/src/analytics.test.ts
@@ -1,0 +1,258 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { normalizeChessComGame, type ChessComGame, type NormalizedGameRecord } from "@chessinsights/domain";
+import { describe, expect, it } from "vitest";
+
+import { buildOpeningSummary } from "./openings.js";
+import { buildOpponentRatingBuckets } from "./opponent-buckets.js";
+import { buildRatingTimeline } from "./rating-timeline.js";
+import { buildResultBreakdown } from "./results.js";
+import { buildTimeClassBreakdown, getMostPlayedTimeClass } from "./time-classes.js";
+
+const fixturePath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../tests/fixtures/chesscom/monthly-games.json"
+);
+
+interface MonthlyGamesFixture {
+  readonly games: ChessComGame[];
+}
+
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8")) as MonthlyGamesFixture;
+
+function normalizedFixtureRecords(): NormalizedGameRecord[] {
+  return fixture.games
+    .map((game) => normalizeChessComGame(game, "testuser"))
+    .filter((record): record is NormalizedGameRecord => record !== null);
+}
+
+describe("analytics aggregations", () => {
+  it("builds result breakdown counts and percentages", () => {
+    expect(buildResultBreakdown(normalizedFixtureRecords())).toEqual({
+      total: 3,
+      win: 1,
+      loss: 1,
+      draw: 1,
+      percentages: {
+        win: 33.3,
+        loss: 33.3,
+        draw: 33.3
+      }
+    });
+  });
+
+  it("filters result breakdowns by time class", () => {
+    expect(buildResultBreakdown(normalizedFixtureRecords(), { timeClass: "rapid" })).toEqual({
+      total: 1,
+      win: 0,
+      loss: 1,
+      draw: 0,
+      percentages: {
+        win: 0,
+        loss: 100,
+        draw: 0
+      }
+    });
+  });
+
+  it("selects the most-played time class with deterministic tie-breaking", () => {
+    expect(getMostPlayedTimeClass(normalizedFixtureRecords())).toBe("blitz");
+    expect(getMostPlayedTimeClass([])).toBeNull();
+  });
+
+  it("builds time-class breakdowns in chart order", () => {
+    expect(buildTimeClassBreakdown(normalizedFixtureRecords())).toEqual([
+      {
+        timeClass: "bullet",
+        total: 0,
+        percentage: 0
+      },
+      {
+        timeClass: "blitz",
+        total: 1,
+        percentage: 33.3
+      },
+      {
+        timeClass: "rapid",
+        total: 1,
+        percentage: 33.3
+      },
+      {
+        timeClass: "daily",
+        total: 1,
+        percentage: 33.3
+      }
+    ]);
+  });
+
+  it("builds a rating timeline sorted by played date", () => {
+    expect(buildRatingTimeline(normalizedFixtureRecords())).toEqual([
+      {
+        playedAt: "2024-01-15T08:26:40.000Z",
+        rating: 1350,
+        gameUrl: "https://www.chess.com/game/live/1001",
+        timeClass: "blitz"
+      },
+      {
+        playedAt: "2024-01-16T18:44:11.000Z",
+        rating: 1402,
+        gameUrl: "https://www.chess.com/game/live/1002",
+        timeClass: "rapid"
+      },
+      {
+        playedAt: "2024-01-17T12:00:00.000Z",
+        rating: 1510,
+        gameUrl: "https://www.chess.com/game/daily/1003",
+        timeClass: "daily"
+      }
+    ]);
+  });
+
+  it("filters rating timelines by time class", () => {
+    expect(buildRatingTimeline(normalizedFixtureRecords(), { timeClass: "blitz" })).toEqual([
+      {
+        playedAt: "2024-01-15T08:26:40.000Z",
+        rating: 1350,
+        gameUrl: "https://www.chess.com/game/live/1001",
+        timeClass: "blitz"
+      }
+    ]);
+  });
+
+  it("groups opponent ratings into deterministic buckets", () => {
+    expect(buildOpponentRatingBuckets(normalizedFixtureRecords())).toEqual({
+      skippedGames: 0,
+      buckets: [
+        {
+          start: 1200,
+          end: 1299,
+          label: "1200-1299",
+          counts: {
+            total: 1,
+            win: 1,
+            loss: 0,
+            draw: 0
+          },
+          percentages: {
+            win: 100,
+            loss: 0,
+            draw: 0
+          }
+        },
+        {
+          start: 1400,
+          end: 1499,
+          label: "1400-1499",
+          counts: {
+            total: 2,
+            win: 0,
+            loss: 1,
+            draw: 1
+          },
+          percentages: {
+            win: 0,
+            loss: 50,
+            draw: 50
+          }
+        }
+      ]
+    });
+  });
+
+  it("tracks skipped games with missing opponent ratings", () => {
+    const [firstRecord] = normalizedFixtureRecords();
+
+    if (firstRecord === undefined) {
+      throw new Error("Expected fixture record");
+    }
+
+    expect(
+      buildOpponentRatingBuckets([
+        {
+          ...firstRecord,
+          opponentRating: null
+        }
+      ])
+    ).toEqual({
+      buckets: [],
+      skippedGames: 1
+    });
+  });
+
+  it("rejects invalid opponent bucket sizes", () => {
+    expect(() => buildOpponentRatingBuckets(normalizedFixtureRecords(), { bucketSize: 0 })).toThrow(TypeError);
+  });
+
+  it("builds opening-family summaries for stacked chart data", () => {
+    expect(buildOpeningSummary(normalizedFixtureRecords())).toEqual([
+      {
+        openingFamily: "Italian Game",
+        counts: {
+          total: 1,
+          win: 0,
+          loss: 1,
+          draw: 0
+        },
+        percentages: {
+          win: 0,
+          loss: 100,
+          draw: 0
+        }
+      },
+      {
+        openingFamily: "Queen's Pawn Opening",
+        counts: {
+          total: 1,
+          win: 0,
+          loss: 0,
+          draw: 1
+        },
+        percentages: {
+          win: 0,
+          loss: 0,
+          draw: 100
+        }
+      },
+      {
+        openingFamily: "Sicilian Defense",
+        counts: {
+          total: 1,
+          win: 1,
+          loss: 0,
+          draw: 0
+        },
+        percentages: {
+          win: 100,
+          loss: 0,
+          draw: 0
+        }
+      }
+    ]);
+  });
+
+  it("supports opening summary limits and time-class filters", () => {
+    expect(buildOpeningSummary(normalizedFixtureRecords(), { limit: 1, timeClass: "blitz" })).toEqual([
+      {
+        openingFamily: "Sicilian Defense",
+        counts: {
+          total: 1,
+          win: 1,
+          loss: 0,
+          draw: 0
+        },
+        percentages: {
+          win: 100,
+          loss: 0,
+          draw: 0
+        }
+      }
+    ]);
+  });
+
+  it("rejects invalid opening summary limits", () => {
+    expect(() => buildOpeningSummary(normalizedFixtureRecords(), { limit: -1 })).toThrow(TypeError);
+  });
+});
+

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,0 +1,7 @@
+export * from "./opponent-buckets.js";
+export * from "./openings.js";
+export * from "./rating-timeline.js";
+export * from "./results.js";
+export * from "./time-classes.js";
+export * from "./types.js";
+

--- a/packages/analytics/src/openings.ts
+++ b/packages/analytics/src/openings.ts
@@ -1,0 +1,52 @@
+import type { NormalizedGameRecord } from "@chessinsights/domain";
+
+import {
+  compareByCountDescThenNameAsc,
+  emptyResultCounts,
+  filterByTimeClass,
+  incrementResult,
+  toPercentages
+} from "./shared.js";
+import type { OpeningSummaryEntry, OpeningSummaryOptions } from "./types.js";
+
+export function buildOpeningSummary(
+  records: readonly NormalizedGameRecord[],
+  options: OpeningSummaryOptions = {}
+): OpeningSummaryEntry[] {
+  const limit = validateLimit(options.limit);
+  const entriesByFamily = new Map<string, OpeningSummaryEntry>();
+
+  for (const record of filterByTimeClass(records, options.timeClass)) {
+    const existingEntry = entriesByFamily.get(record.openingFamily) ?? {
+      openingFamily: record.openingFamily,
+      counts: emptyResultCounts(),
+      percentages: toPercentages(emptyResultCounts())
+    };
+    const counts = incrementResult(existingEntry.counts, record.result);
+
+    entriesByFamily.set(record.openingFamily, {
+      ...existingEntry,
+      counts,
+      percentages: toPercentages(counts)
+    });
+  }
+
+  const entries = [...entriesByFamily.values()].sort((left, right) =>
+    compareByCountDescThenNameAsc(left.openingFamily, left.counts.total, right.openingFamily, right.counts.total)
+  );
+
+  return limit === undefined ? entries : entries.slice(0, limit);
+}
+
+function validateLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined) {
+    return undefined;
+  }
+
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new TypeError("Opening summary limit must be a non-negative integer.");
+  }
+
+  return limit;
+}
+

--- a/packages/analytics/src/opponent-buckets.ts
+++ b/packages/analytics/src/opponent-buckets.ts
@@ -1,0 +1,59 @@
+import type { NormalizedGameRecord } from "@chessinsights/domain";
+
+import { emptyResultCounts, filterByTimeClass, incrementResult, toPercentages } from "./shared.js";
+import type { OpponentRatingBucket, OpponentRatingBucketOptions, OpponentRatingBucketsResult } from "./types.js";
+
+const DEFAULT_BUCKET_SIZE = 100;
+
+export function buildOpponentRatingBuckets(
+  records: readonly NormalizedGameRecord[],
+  options: OpponentRatingBucketOptions = {}
+): OpponentRatingBucketsResult {
+  const bucketSize = validateBucketSize(options.bucketSize ?? DEFAULT_BUCKET_SIZE);
+  const bucketsByStart = new Map<number, OpponentRatingBucket>();
+  let skippedGames = 0;
+
+  for (const record of filterByTimeClass(records, options.timeClass)) {
+    if (record.opponentRating === null) {
+      skippedGames += 1;
+      continue;
+    }
+
+    const start = Math.floor(record.opponentRating / bucketSize) * bucketSize;
+    const existingBucket = bucketsByStart.get(start) ?? createBucket(start, bucketSize);
+    const counts = incrementResult(existingBucket.counts, record.result);
+
+    bucketsByStart.set(start, {
+      ...existingBucket,
+      counts,
+      percentages: toPercentages(counts)
+    });
+  }
+
+  return {
+    buckets: [...bucketsByStart.values()].sort((left, right) => left.start - right.start),
+    skippedGames
+  };
+}
+
+function createBucket(start: number, bucketSize: number): OpponentRatingBucket {
+  const end = start + bucketSize - 1;
+  const counts = emptyResultCounts();
+
+  return {
+    start,
+    end,
+    label: `${start}-${end}`,
+    counts,
+    percentages: toPercentages(counts)
+  };
+}
+
+function validateBucketSize(bucketSize: number): number {
+  if (!Number.isInteger(bucketSize) || bucketSize <= 0) {
+    throw new TypeError("Opponent rating bucket size must be a positive integer.");
+  }
+
+  return bucketSize;
+}
+

--- a/packages/analytics/src/rating-timeline.ts
+++ b/packages/analytics/src/rating-timeline.ts
@@ -1,0 +1,30 @@
+import type { NormalizedGameRecord } from "@chessinsights/domain";
+
+import { filterByTimeClass } from "./shared.js";
+import type { RatingTimelineOptions, RatingTimelinePoint } from "./types.js";
+
+export function buildRatingTimeline(
+  records: readonly NormalizedGameRecord[],
+  options: RatingTimelineOptions = {}
+): RatingTimelinePoint[] {
+  return filterByTimeClass(records, options.timeClass)
+    .filter((record) => record.playedAt !== null && record.playerRating !== null)
+    .map((record) => ({
+      playedAt: record.playedAt as string,
+      rating: record.playerRating as number,
+      gameUrl: record.gameUrl,
+      timeClass: record.timeClass
+    }))
+    .sort(compareTimelinePoints);
+}
+
+function compareTimelinePoints(left: RatingTimelinePoint, right: RatingTimelinePoint): number {
+  const playedAtCompare = left.playedAt.localeCompare(right.playedAt);
+
+  if (playedAtCompare !== 0) {
+    return playedAtCompare;
+  }
+
+  return left.gameUrl.localeCompare(right.gameUrl);
+}
+

--- a/packages/analytics/src/results.ts
+++ b/packages/analytics/src/results.ts
@@ -1,0 +1,17 @@
+import type { NormalizedGameRecord } from "@chessinsights/domain";
+
+import { emptyResultCounts, filterByTimeClass, incrementResult, toResultBreakdown } from "./shared.js";
+import type { ResultBreakdown, TimeClassFilter } from "./types.js";
+
+export function buildResultBreakdown(
+  records: readonly NormalizedGameRecord[],
+  options: TimeClassFilter = {}
+): ResultBreakdown {
+  const counts = filterByTimeClass(records, options.timeClass).reduce(
+    (currentCounts, record) => incrementResult(currentCounts, record.result),
+    emptyResultCounts()
+  );
+
+  return toResultBreakdown(counts);
+}
+

--- a/packages/analytics/src/shared.ts
+++ b/packages/analytics/src/shared.ts
@@ -1,0 +1,70 @@
+import type { NormalizedGameRecord, NormalizedResult, TimeClass } from "@chessinsights/domain";
+
+import type { ResultBreakdown, ResultCounts, ResultPercentages } from "./types.js";
+
+export const TIME_CLASS_ORDER: readonly TimeClass[] = ["bullet", "blitz", "rapid", "daily"];
+
+export function emptyResultCounts(): ResultCounts {
+  return {
+    total: 0,
+    win: 0,
+    loss: 0,
+    draw: 0
+  };
+}
+
+export function incrementResult(counts: ResultCounts, result: NormalizedResult): ResultCounts {
+  return {
+    ...counts,
+    total: counts.total + 1,
+    [result]: counts[result] + 1
+  };
+}
+
+export function toResultBreakdown(counts: ResultCounts): ResultBreakdown {
+  return {
+    ...counts,
+    percentages: toPercentages(counts)
+  };
+}
+
+export function toPercentages(counts: ResultCounts): ResultPercentages {
+  return {
+    win: percentage(counts.win, counts.total),
+    loss: percentage(counts.loss, counts.total),
+    draw: percentage(counts.draw, counts.total)
+  };
+}
+
+export function percentage(count: number, total: number): number {
+  if (total === 0) {
+    return 0;
+  }
+
+  return Math.round((count / total) * 1000) / 10;
+}
+
+export function filterByTimeClass(
+  records: readonly NormalizedGameRecord[],
+  timeClass: TimeClass | undefined
+): NormalizedGameRecord[] {
+  if (timeClass === undefined) {
+    return [...records];
+  }
+
+  return records.filter((record) => record.timeClass === timeClass);
+}
+
+export function compareByCountDescThenNameAsc(
+  leftName: string,
+  leftCount: number,
+  rightName: string,
+  rightCount: number
+): number {
+  if (leftCount !== rightCount) {
+    return rightCount - leftCount;
+  }
+
+  return leftName.localeCompare(rightName);
+}
+

--- a/packages/analytics/src/time-classes.ts
+++ b/packages/analytics/src/time-classes.ts
@@ -1,0 +1,47 @@
+import type { NormalizedGameRecord, TimeClass } from "@chessinsights/domain";
+
+import { percentage, TIME_CLASS_ORDER } from "./shared.js";
+import type { TimeClassBreakdownEntry } from "./types.js";
+
+export function getMostPlayedTimeClass(records: readonly NormalizedGameRecord[]): TimeClass | null {
+  const counts = countByTimeClass(records);
+
+  return TIME_CLASS_ORDER.reduce<TimeClass | null>((currentBest, timeClass) => {
+    if (counts[timeClass] === 0) {
+      return currentBest;
+    }
+
+    if (currentBest === null || counts[timeClass] > counts[currentBest]) {
+      return timeClass;
+    }
+
+    return currentBest;
+  }, null);
+}
+
+export function buildTimeClassBreakdown(records: readonly NormalizedGameRecord[]): TimeClassBreakdownEntry[] {
+  const counts = countByTimeClass(records);
+  const total = records.length;
+
+  return TIME_CLASS_ORDER.map((timeClass) => ({
+    timeClass,
+    total: counts[timeClass],
+    percentage: percentage(counts[timeClass], total)
+  }));
+}
+
+function countByTimeClass(records: readonly NormalizedGameRecord[]): Record<TimeClass, number> {
+  const counts: Record<TimeClass, number> = {
+    bullet: 0,
+    blitz: 0,
+    rapid: 0,
+    daily: 0
+  };
+
+  for (const record of records) {
+    counts[record.timeClass] += 1;
+  }
+
+  return counts;
+}
+

--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -1,0 +1,66 @@
+import type { NormalizedGameRecord, TimeClass } from "@chessinsights/domain";
+
+export interface TimeClassFilter {
+  readonly timeClass?: TimeClass;
+}
+
+export interface ResultCounts {
+  readonly total: number;
+  readonly win: number;
+  readonly loss: number;
+  readonly draw: number;
+}
+
+export interface ResultPercentages {
+  readonly win: number;
+  readonly loss: number;
+  readonly draw: number;
+}
+
+export interface ResultBreakdown extends ResultCounts {
+  readonly percentages: ResultPercentages;
+}
+
+export interface TimeClassBreakdownEntry {
+  readonly timeClass: TimeClass;
+  readonly total: number;
+  readonly percentage: number;
+}
+
+export interface RatingTimelinePoint {
+  readonly playedAt: string;
+  readonly rating: number;
+  readonly gameUrl: string;
+  readonly timeClass: TimeClass;
+}
+
+export type RatingTimelineOptions = TimeClassFilter;
+
+export interface OpponentRatingBucket {
+  readonly start: number;
+  readonly end: number;
+  readonly label: string;
+  readonly counts: ResultCounts;
+  readonly percentages: ResultPercentages;
+}
+
+export interface OpponentRatingBucketOptions extends TimeClassFilter {
+  readonly bucketSize?: number;
+}
+
+export interface OpponentRatingBucketsResult {
+  readonly buckets: OpponentRatingBucket[];
+  readonly skippedGames: number;
+}
+
+export interface OpeningSummaryEntry {
+  readonly openingFamily: string;
+  readonly counts: ResultCounts;
+  readonly percentages: ResultPercentages;
+}
+
+export interface OpeningSummaryOptions extends TimeClassFilter {
+  readonly limit?: number;
+}
+
+export type AnalyticsInput = readonly NormalizedGameRecord[];


### PR DESCRIPTION
## Summary

Adds `@chessinsights/analytics`, a pure in-memory aggregation package for normalized game records. It builds dashboard-ready result breakdowns, time-class breakdowns, default most-played time class, rating timeline points, opponent rating buckets, and opening-family summaries.

Closes #8.

## Changed files

- `packages/analytics/package.json`: workspace package metadata and domain dependency.
- `packages/analytics/src/results.ts`: result counts and percentages.
- `packages/analytics/src/time-classes.ts`: time-class breakdown and most-played default selection.
- `packages/analytics/src/rating-timeline.ts`: sorted rating timeline points.
- `packages/analytics/src/opponent-buckets.ts`: opponent rating buckets with labels and percentages.
- `packages/analytics/src/openings.ts`: opening-family stacked chart summaries and top-N limiting.
- `packages/analytics/src/shared.ts`, `types.ts`, `index.ts`: shared helpers, public types, and exports.
- `packages/analytics/src/analytics.test.ts`: fixture-backed regression tests using existing Chess.com game fixtures and the domain normalizer.
- `package-lock.json`: workspace link and internal package dependency metadata.

## Validation

- [x] Relevant tests run
- [x] Lint ran, if applicable
- [x] Typecheck ran, if applicable
- [ ] Build ran for user-visible web changes, if applicable
- [x] Behavior changes include or update regression tests
- [x] PR summary explains changed files and test results

Commands run:

```text
npm install
npm run lint
npm run typecheck
npm run test
git diff --check
npm run lint -w @chessinsights/analytics
npm run typecheck -w @chessinsights/analytics
npm run test -w @chessinsights/analytics
```

Commands not run / reason:

```text
npm run build - no build script or user-visible web app exists yet.
Live Chess.com calls - intentionally not run; analytics tests use normalized records from local fixtures only.
```

## Risk / rollout

- [x] No provider, scraper, queue, or rate-limit behavior changed
- [x] No database schema or migration changed
- [x] No user-visible behavior changed
- [x] Rollback or follow-up plan is documented below, if needed

Notes:

This PR is pure and side-effect-free. It does not add SQL, persistence, API routes, frontend charts, or import fetching. Percentages are rounded to one decimal place; bucket and sort behavior is deterministic and covered by tests.

Follow-up work: wire these aggregate contracts into persistence/query code, then expose them through route handlers for the dashboard.

## CodeRabbit follow-up

No CodeRabbit follow-up yet; this is the initial PR for issue #8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new analytics package with comprehensive game analysis capabilities, including result breakdowns with percentages, rating progression timelines, opening family summaries with performance metrics, opponent rating distribution analysis, and time-class performance breakdowns.

* **Tests**
  * Added comprehensive test coverage for all analytics functions and their filtering options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->