### PR TITLE
Add database persistence contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,11 @@ jobs:
           done
 
           case " $scripts " in
+            *" db:validate "*) "$pm" run db:validate ;;
+            *) echo "No db:validate script defined; skipping database schema validation." ;;
+          esac
+
+          case " $scripts " in
             *" build "*) "$pm" run build ;;
             *) echo "No build script defined; skipping build." ;;
           esac

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,10 @@
       "resolved": "packages/chesscom-client",
       "link": true
     },
+    "node_modules/@chessinsights/db": {
+      "resolved": "packages/db",
+      "link": true
+    },
     "node_modules/@chessinsights/domain": {
       "resolved": "packages/domain",
       "link": true
@@ -1074,6 +1078,33 @@
         "node": ">=18"
       }
     },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1121,6 +1152,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1129,6 +1184,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/empathic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1323,6 +1388,36 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1490,6 +1585,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -1884,6 +1989,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nypm": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.6.tgz",
+      "integrity": "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.2.2",
+        "pathe": "^2.0.3",
+        "tinyexec": "^1.1.1"
+      },
+      "bin": {
+        "nypm": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -1893,6 +2030,13 @@
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
+      "license": "MIT"
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -1992,6 +2136,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkg-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
+        "pathe": "^2.0.3"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
@@ -2040,6 +2196,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.17",
@@ -2509,6 +2682,224 @@
     "packages/chesscom-client": {
       "name": "@chessinsights/chesscom-client",
       "version": "0.1.0"
+    },
+    "packages/db": {
+      "name": "@chessinsights/db",
+      "version": "0.1.0",
+      "dependencies": {
+        "@chessinsights/domain": "file:../domain"
+      },
+      "devDependencies": {
+        "prisma": "^6.19.3"
+      }
+    },
+    "packages/db/node_modules/@prisma/config": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
+      "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "c12": "3.1.0",
+        "deepmerge-ts": "7.1.5",
+        "effect": "3.21.0",
+        "empathic": "2.0.0"
+      }
+    },
+    "packages/db/node_modules/@prisma/debug": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
+      "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "packages/db/node_modules/@prisma/engines": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
+      "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.19.3",
+        "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/fetch-engine": "6.19.3",
+        "@prisma/get-platform": "6.19.3"
+      }
+    },
+    "packages/db/node_modules/@prisma/engines-version": {
+      "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
+      "integrity": "sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "packages/db/node_modules/@prisma/fetch-engine": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
+      "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.19.3",
+        "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/get-platform": "6.19.3"
+      }
+    },
+    "packages/db/node_modules/@prisma/get-platform": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
+      "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.19.3"
+      }
+    },
+    "packages/db/node_modules/c12": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
+      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.3",
+        "confbox": "^0.2.2",
+        "defu": "^6.1.4",
+        "dotenv": "^16.6.1",
+        "exsolve": "^1.0.7",
+        "giget": "^2.0.0",
+        "jiti": "^2.4.2",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^1.0.0",
+        "pkg-types": "^2.2.0",
+        "rc9": "^2.1.2"
+      },
+      "peerDependencies": {
+        "magicast": "^0.3.5"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
+      }
+    },
+    "packages/db/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/db/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "packages/db/node_modules/effect": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
+    "packages/db/node_modules/giget": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.0",
+        "defu": "^6.1.4",
+        "node-fetch-native": "^1.6.6",
+        "nypm": "^0.6.0",
+        "pathe": "^2.0.3"
+      },
+      "bin": {
+        "giget": "dist/cli.mjs"
+      }
+    },
+    "packages/db/node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/db/node_modules/prisma": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
+      "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.19.3",
+        "@prisma/engines": "6.19.3"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/db/node_modules/rc9": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "destr": "^2.0.3"
+      }
+    },
+    "packages/db/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "packages/domain": {
       "name": "@chessinsights/domain",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "packages/*"
   ],
   "scripts": {
+    "db:validate": "npm --workspace @chessinsights/db run prisma:validate",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@chessinsights/db",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "npm --prefix ../.. run lint",
+    "prisma:validate": "PRISMA_HIDE_UPDATE_MESSAGE=true DATABASE_URL=${DATABASE_URL:-postgresql://chessinsights:chessinsights@localhost:5432/chessinsights} prisma validate --schema prisma/schema.prisma",
+    "typecheck": "npm --prefix ../.. run typecheck",
+    "test": "npm --prefix ../.. run test"
+  },
+  "dependencies": {
+    "@chessinsights/domain": "file:../domain"
+  },
+  "devDependencies": {
+    "prisma": "^6.19.3"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "lint": "npm --prefix ../.. run lint",
-    "prisma:validate": "PRISMA_HIDE_UPDATE_MESSAGE=true DATABASE_URL=${DATABASE_URL:-postgresql://chessinsights:chessinsights@localhost:5432/chessinsights} prisma validate --schema prisma/schema.prisma",
+    "prisma:validate": "PRISMA_HIDE_UPDATE_MESSAGE=true DATABASE_URL=${DATABASE_URL:-postgresql://localhost:5432/chessinsights} prisma validate --schema prisma/schema.prisma",
     "typecheck": "npm --prefix ../.. run typecheck",
     "test": "npm --prefix ../.. run test"
   },

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1,0 +1,228 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum AggregateKind {
+  opening_summary
+  opponent_rating_buckets
+  rating_timeline
+  result_breakdown
+  time_class_breakdown
+}
+
+enum ArchiveFetchStatus {
+  failed
+  fetched
+  pending
+  skipped
+}
+
+enum GameEnding {
+  abandoned
+  agreement
+  checkmate
+  fifty_move
+  insufficient_material
+  repetition
+  resignation
+  stalemate
+  timeout
+  time_vs_insufficient_material
+  unknown
+}
+
+enum GamePlayerColor {
+  black
+  white
+}
+
+enum GameResult {
+  draw
+  loss
+  win
+}
+
+enum GameTimeClass {
+  blitz
+  bullet
+  daily
+  rapid
+}
+
+enum ImportJobStatus {
+  canceled
+  completed
+  failed
+  queued
+  running
+}
+
+enum ProviderResponseKind {
+  archive_list
+  monthly_archive
+  player_profile
+  player_stats
+}
+
+model AggregateSnapshot {
+  id           String         @id @default(cuid())
+  playerId     String
+  kind         AggregateKind
+  timeClass    GameTimeClass?
+  timeClassKey String         @default("all")
+  filterHash   String
+  payload      Json
+  recordCount  Int
+  computedAt   DateTime       @default(now())
+  createdAt    DateTime       @default(now())
+  player       Player         @relation(fields: [playerId], references: [id], onDelete: Cascade)
+
+  @@unique([playerId, kind, timeClassKey, filterHash])
+  @@index([playerId, kind, computedAt])
+}
+
+model Archive {
+  id                 String             @id @default(cuid())
+  playerId           String
+  year               Int
+  month              Int
+  url                String             @unique
+  status             ArchiveFetchStatus @default(pending)
+  etag               String?
+  lastModified       String?
+  fetchedAt          DateTime?
+  gameCount          Int                @default(0)
+  checksum           String?
+  rawPayload         Json?
+  providerResponseId String?            @unique
+  createdAt          DateTime           @default(now())
+  updatedAt          DateTime           @updatedAt
+  player             Player             @relation(fields: [playerId], references: [id], onDelete: Cascade)
+  providerResponse   ProviderResponse?  @relation(fields: [providerResponseId], references: [id], onDelete: SetNull)
+  rawGames           RawGame[]
+
+  @@unique([playerId, year, month])
+  @@index([playerId, fetchedAt])
+}
+
+model Game {
+  id                     String          @id @default(cuid())
+  playerId               String
+  rawGameId              String?         @unique
+  gameUrl                String          @unique
+  opponentUsername       String
+  playerColor            GamePlayerColor
+  playerRating           Int?
+  opponentRating         Int?
+  timeClass              GameTimeClass
+  result                 GameResult
+  ending                 GameEnding
+  rawPlayerResult        String
+  rawOpponentResult      String
+  rawRules               String
+  rawTimeClass           String
+  openingName            String
+  openingFamily          String
+  openingTaxonomyVersion String
+  playedAt               DateTime?
+  moveCount              Int
+  plyCount               Int
+  rated                  Boolean?
+  createdAt              DateTime        @default(now())
+  updatedAt              DateTime        @updatedAt
+  player                 Player          @relation(fields: [playerId], references: [id], onDelete: Cascade)
+  rawGame                RawGame?        @relation(fields: [rawGameId], references: [id], onDelete: SetNull)
+
+  @@index([playerId, timeClass, playedAt])
+  @@index([playerId, opponentRating])
+  @@index([playerId, openingFamily, timeClass])
+  @@index([playerId, result, timeClass])
+  @@index([playedAt])
+}
+
+model ImportJob {
+  id                  String          @id @default(cuid())
+  playerId            String?
+  requestedUsername   String
+  usernameKey         String
+  status              ImportJobStatus @default(queued)
+  archiveCount        Int             @default(0)
+  fetchedArchiveCount Int             @default(0)
+  recordCount         Int             @default(0)
+  skippedGameCount    Int             @default(0)
+  skippedArchiveUrls  Json?
+  errorCode           String?
+  errorMessage        String?
+  startedAt           DateTime?
+  completedAt         DateTime?
+  createdAt           DateTime        @default(now())
+  updatedAt           DateTime        @updatedAt
+  player              Player?         @relation(fields: [playerId], references: [id], onDelete: SetNull)
+
+  @@index([usernameKey, createdAt])
+  @@index([status, createdAt])
+}
+
+model Player {
+  id                 String              @id @default(cuid())
+  chessComUsername   String
+  usernameKey        String              @unique
+  chessComPlayerId   BigInt?             @unique
+  avatarUrl          String?
+  profileUrl         String?
+  status             String?
+  countryUrl         String?
+  lastImportedAt     DateTime?
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @updatedAt
+  aggregateSnapshots AggregateSnapshot[]
+  archives           Archive[]
+  games              Game[]
+  importJobs         ImportJob[]
+  providerResponses  ProviderResponse[]
+  rawGames           RawGame[]
+
+  @@index([lastImportedAt])
+}
+
+model ProviderResponse {
+  id              String               @id @default(cuid())
+  playerId        String?
+  kind            ProviderResponseKind
+  url             String
+  statusCode      Int
+  requestHeaders  Json?
+  responseHeaders Json?
+  etag            String?
+  lastModified    String?
+  body            Json?
+  checksum        String?
+  fetchedAt       DateTime             @default(now())
+  archive         Archive?
+  player          Player?              @relation(fields: [playerId], references: [id], onDelete: SetNull)
+
+  @@index([playerId, kind, fetchedAt])
+  @@index([url, fetchedAt])
+}
+
+model RawGame {
+  id             String   @id @default(cuid())
+  playerId       String
+  archiveId      String
+  gameUrl        String   @unique
+  pgn            String
+  raw            Json
+  checksum       String
+  fetchedAt      DateTime @default(now())
+  archive        Archive  @relation(fields: [archiveId], references: [id], onDelete: Cascade)
+  normalizedGame Game?
+  player         Player   @relation(fields: [playerId], references: [id], onDelete: Cascade)
+
+  @@index([playerId, archiveId])
+  @@index([checksum])
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -74,7 +74,7 @@ model AggregateSnapshot {
   playerId     String
   kind         AggregateKind
   timeClass    GameTimeClass?
-  timeClassKey String         @default("all")
+  timeClassKey String
   filterHash   String
   payload      Json
   recordCount  Int

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -114,7 +114,7 @@ model Game {
   id                     String          @id @default(cuid())
   playerId               String
   rawGameId              String?         @unique
-  gameUrl                String          @unique
+  gameUrl                String
   opponentUsername       String
   playerColor            GamePlayerColor
   playerRating           Int?
@@ -138,6 +138,7 @@ model Game {
   player                 Player          @relation(fields: [playerId], references: [id], onDelete: Cascade)
   rawGame                RawGame?        @relation(fields: [rawGameId], references: [id], onDelete: SetNull)
 
+  @@unique([playerId, gameUrl])
   @@index([playerId, timeClass, playedAt])
   @@index([playerId, opponentRating])
   @@index([playerId, openingFamily, timeClass])
@@ -214,7 +215,7 @@ model RawGame {
   id             String   @id @default(cuid())
   playerId       String
   archiveId      String
-  gameUrl        String   @unique
+  gameUrl        String
   pgn            String
   raw            Json
   checksum       String
@@ -223,6 +224,7 @@ model RawGame {
   normalizedGame Game?
   player         Player   @relation(fields: [playerId], references: [id], onDelete: Cascade)
 
+  @@unique([playerId, gameUrl])
   @@index([playerId, archiveId])
   @@index([checksum])
 }

--- a/packages/db/src/game-record.test.ts
+++ b/packages/db/src/game-record.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeChessComGame,
+  type ChessComGame,
+  type NormalizedGameRecord
+} from "@chessinsights/domain";
+
+import monthlyGamesFixture from "../../../tests/fixtures/chesscom/monthly-games.json" with {
+  type: "json"
+};
+import {
+  createAggregateFilterHash,
+  DEFAULT_OPENING_TAXONOMY_VERSION,
+  toGameWriteModel,
+  toUsernameKey
+} from "./index.js";
+
+const fixtureGames = monthlyGamesFixture.games as ChessComGame[];
+const fixtureRecords = fixtureGames
+  .map((game) => normalizeChessComGame(game, "TestUser"))
+  .filter((record): record is NormalizedGameRecord => record !== null);
+
+describe("database persistence helpers", () => {
+  it("maps a normalized game into a persistence-safe write model", () => {
+    const record = getFixtureRecord(0);
+
+    const writeModel = toGameWriteModel({
+      playerId: "player_123",
+      rawGameId: "raw_game_123",
+      record
+    });
+
+    expect(writeModel).toEqual({
+      playerId: "player_123",
+      rawGameId: "raw_game_123",
+      gameUrl: "https://www.chess.com/game/live/1001",
+      opponentUsername: "OpponentOne",
+      playerColor: "white",
+      playerRating: 1350,
+      opponentRating: 1288,
+      timeClass: "blitz",
+      result: "win",
+      ending: "resignation",
+      rawPlayerResult: "win",
+      rawOpponentResult: "resigned",
+      rawRules: "chess",
+      rawTimeClass: "blitz",
+      openingName: "Sicilian Defense Najdorf Variation",
+      openingFamily: "Sicilian Defense",
+      openingTaxonomyVersion: DEFAULT_OPENING_TAXONOMY_VERSION,
+      playedAt: new Date("2024-01-15T08:26:40.000Z"),
+      moveCount: 5,
+      plyCount: 10,
+      rated: true
+    });
+  });
+
+  it("keeps the raw game id optional for delayed raw-game backfills", () => {
+    const record = getFixtureRecord(1);
+
+    const writeModel = toGameWriteModel({
+      playerId: "player_123",
+      record
+    });
+
+    expect(writeModel.rawGameId).toBeUndefined();
+    expect(writeModel.playedAt).toEqual(new Date("2024-01-16T18:44:11.000Z"));
+  });
+
+  it("rejects invalid playedAt values before they reach the database", () => {
+    const record = getFixtureRecord(0);
+
+    expect(() =>
+      toGameWriteModel({
+        playerId: "player_123",
+        record: {
+          ...record,
+          playedAt: "not-a-date"
+        }
+      })
+    ).toThrow(/Cannot persist invalid playedAt value/);
+  });
+
+  it("normalizes Chess.com usernames into stable lookup keys", () => {
+    expect(toUsernameKey("  TestUser  ")).toBe("testuser");
+    expect(() => toUsernameKey("   ")).toThrow(/must not be empty/);
+  });
+
+  it("creates deterministic aggregate filter hashes regardless of key order", () => {
+    const firstHash = createAggregateFilterHash({
+      bucketSize: 100,
+      timeClass: "rapid",
+      limit: 10
+    });
+    const secondHash = createAggregateFilterHash({
+      limit: 10,
+      timeClass: "rapid",
+      bucketSize: 100
+    });
+
+    expect(firstHash).toBe(secondHash);
+    expect(firstHash).toHaveLength(64);
+  });
+});
+
+function getFixtureRecord(index: number): NormalizedGameRecord {
+  const record = fixtureRecords[index];
+
+  if (record === undefined) {
+    throw new Error(`Missing fixture record at index ${index}.`);
+  }
+
+  return record;
+}

--- a/packages/db/src/game-record.ts
+++ b/packages/db/src/game-record.ts
@@ -1,0 +1,51 @@
+import type { NormalizedGameRecord } from "@chessinsights/domain";
+
+import {
+  DEFAULT_OPENING_TAXONOMY_VERSION,
+  type GameWriteInput,
+  type GameWriteModel
+} from "./types.js";
+
+export function toGameWriteModel(input: GameWriteInput): GameWriteModel {
+  const openingTaxonomyVersion =
+    input.openingTaxonomyVersion ?? DEFAULT_OPENING_TAXONOMY_VERSION;
+  const playedAt = toNullableDate(input.record.playedAt, input.record.gameUrl);
+
+  return {
+    ...(input.rawGameId === undefined ? {} : { rawGameId: input.rawGameId }),
+    playerId: input.playerId,
+    gameUrl: input.record.gameUrl,
+    opponentUsername: input.record.opponentUsername,
+    playerColor: input.record.playerColor,
+    playerRating: input.record.playerRating,
+    opponentRating: input.record.opponentRating,
+    timeClass: input.record.timeClass,
+    result: input.record.result,
+    ending: input.record.ending,
+    rawPlayerResult: input.record.rawPlayerResult,
+    rawOpponentResult: input.record.rawOpponentResult,
+    rawRules: input.record.rawRules,
+    rawTimeClass: input.record.rawTimeClass,
+    openingName: input.record.openingName,
+    openingFamily: input.record.openingFamily,
+    openingTaxonomyVersion,
+    playedAt,
+    moveCount: input.record.moveCount,
+    plyCount: input.record.plyCount,
+    rated: input.record.rated
+  };
+}
+
+function toNullableDate(value: NormalizedGameRecord["playedAt"], gameUrl: string): Date | null {
+  if (value === null) {
+    return null;
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new TypeError(`Cannot persist invalid playedAt value for ${gameUrl}: ${value}`);
+  }
+
+  return date;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./game-record.js";
+export * from "./snapshot-key.js";
+export * from "./types.js";
+export * from "./username.js";

--- a/packages/db/src/snapshot-key.ts
+++ b/packages/db/src/snapshot-key.ts
@@ -1,0 +1,25 @@
+import { createHash } from "node:crypto";
+
+import type { AggregateFilterInput } from "./types.js";
+
+export function createAggregateFilterHash(filters: AggregateFilterInput): string {
+  return createHash("sha256").update(stableJson(filters)).digest("hex");
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
+  }
+
+  if (value !== null && typeof value === "object") {
+    const entries = Object.entries(value)
+      .filter(([, entryValue]) => entryValue !== undefined)
+      .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey));
+
+    return `{${entries
+      .map(([entryKey, entryValue]) => `${JSON.stringify(entryKey)}:${stableJson(entryValue)}`)
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value);
+}

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -1,0 +1,55 @@
+import type {
+  EndingCategory,
+  NormalizedGameRecord,
+  NormalizedResult,
+  PlayerColor,
+  TimeClass
+} from "@chessinsights/domain";
+
+export const DEFAULT_OPENING_TAXONOMY_VERSION = "opening-family:v1";
+
+export type AggregateKind =
+  | "opening_summary"
+  | "opponent_rating_buckets"
+  | "rating_timeline"
+  | "result_breakdown"
+  | "time_class_breakdown";
+
+export interface AggregateFilterInput {
+  readonly bucketSize?: number;
+  readonly from?: string;
+  readonly limit?: number;
+  readonly timeClass?: TimeClass;
+  readonly to?: string;
+}
+
+export interface GameWriteInput {
+  readonly playerId: string;
+  readonly rawGameId?: string;
+  readonly record: NormalizedGameRecord;
+  readonly openingTaxonomyVersion?: string;
+}
+
+export interface GameWriteModel {
+  readonly playerId: string;
+  readonly rawGameId?: string;
+  readonly gameUrl: string;
+  readonly opponentUsername: string;
+  readonly playerColor: PlayerColor;
+  readonly playerRating: number | null;
+  readonly opponentRating: number | null;
+  readonly timeClass: TimeClass;
+  readonly result: NormalizedResult;
+  readonly ending: EndingCategory;
+  readonly rawPlayerResult: string;
+  readonly rawOpponentResult: string;
+  readonly rawRules: string;
+  readonly rawTimeClass: string;
+  readonly openingName: string;
+  readonly openingFamily: string;
+  readonly openingTaxonomyVersion: string;
+  readonly playedAt: Date | null;
+  readonly moveCount: number;
+  readonly plyCount: number;
+  readonly rated: boolean | null;
+}

--- a/packages/db/src/username.ts
+++ b/packages/db/src/username.ts
@@ -1,0 +1,9 @@
+export function toUsernameKey(username: string): string {
+  const usernameKey = username.trim().toLowerCase();
+
+  if (usernameKey.length === 0) {
+    throw new TypeError("Chess.com username must not be empty.");
+  }
+
+  return usernameKey;
+}


### PR DESCRIPTION
## Summary

Adds the first database persistence contract for ChessInsights. Closes #10.

This introduces a `@chessinsights/db` workspace package with a Prisma PostgreSQL schema for players, import jobs, provider responses, archives, raw games, normalized games, and aggregate snapshots. It also adds pure TypeScript helpers for normalized game write models, username keys, and deterministic aggregate filter hashes.

## Changed files

- `packages/db/prisma/schema.prisma`: core Postgres data model and analytics/import indexes.
- `packages/db/src/*`: persistence helper types, normalized-game mapping, username keying, aggregate filter hashing, and fixture-backed tests.
- `package.json`, `package-lock.json`: workspace script/dependency updates for DB validation.
- `.github/workflows/ci.yml`: runs `db:validate` when the root script exists.

## Validation

- [x] Relevant tests run
- [x] Lint ran, if applicable
- [x] Typecheck ran, if applicable
- [ ] Build ran for user-visible web changes, if applicable
- [x] Behavior changes include or update regression tests
- [x] PR summary explains changed files and test results

Commands run:

```text
npm install
npm run lint
npm run typecheck
npm run test
npm run db:validate
npm audit --audit-level=moderate
git diff --check
```

Commands not run / reason:

```text
npm run build - no build script exists and this PR does not add user-visible web code.
Live Chess.com calls - not needed; tests use committed fixtures.
Live PostgreSQL/Testcontainers - out of scope for this schema-contract PR.
```

## Risk / rollout

- [x] No provider, scraper, queue, or rate-limit behavior changed
- [ ] No database schema or migration changed
- [x] No user-visible behavior changed
- [x] Rollback or follow-up plan is documented below, if needed

Notes:

This PR adds a schema contract but does not run migrations or connect to a live database. Prisma CLI is pinned to `^6.19.3` because the latest 7.x CLI currently introduced a moderate dev-only audit advisory through its transitive dependencies during validation; `npm audit --audit-level=moderate` is clean on this branch.

Follow-up work should add a real Prisma client wrapper, migrations, and integration tests once the worker begins persisting imports.

## CodeRabbit follow-up

Addressed three actionable comments:

- Removed credential-shaped placeholder user/password from the `DATABASE_URL` fallback used by `prisma:validate`.
- Scoped `Game.gameUrl` and `RawGame.gameUrl` uniqueness by `playerId` so the same Chess.com game can be imported from both players' perspectives.
- Removed the `AggregateSnapshot.timeClassKey` default so snapshot writers must choose the canonical key explicitly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database package with models to persist players, games, archives, imports, provider responses, and aggregate snapshots.
  * Added username normalization and deterministic aggregate-filter hashing for consistent lookups.

* **Chores**
  * Added a database schema validation script and integrated a conditional validation step into CI.

* **Tests**
  * Added tests for game mapping, playedAt validation, username handling, and aggregate-hash determinism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->