### PR TITLE
Add dashboard analysis service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,10 @@
         "vitest": "^4.1.5"
       }
     },
+    "node_modules/@chessinsights/analysis": {
+      "resolved": "packages/analysis",
+      "link": true
+    },
     "node_modules/@chessinsights/analytics": {
       "resolved": "packages/analytics",
       "link": true
@@ -2670,6 +2674,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/analysis": {
+      "name": "@chessinsights/analysis",
+      "version": "0.1.0",
+      "dependencies": {
+        "@chessinsights/analytics": "file:../analytics",
+        "@chessinsights/domain": "file:../domain",
+        "@chessinsights/importer": "file:../importer"
+      },
+      "devDependencies": {
+        "@chessinsights/chesscom-client": "file:../chesscom-client"
       }
     },
     "packages/analytics": {

--- a/packages/analysis/package.json
+++ b/packages/analysis/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@chessinsights/analysis",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "npm --prefix ../.. run lint",
+    "typecheck": "npm --prefix ../.. run typecheck",
+    "test": "npm --prefix ../.. run test"
+  },
+  "dependencies": {
+    "@chessinsights/analytics": "file:../analytics",
+    "@chessinsights/domain": "file:../domain",
+    "@chessinsights/importer": "file:../importer"
+  },
+  "devDependencies": {
+    "@chessinsights/chesscom-client": "file:../chesscom-client"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/analysis/src/analyze-player.test.ts
+++ b/packages/analysis/src/analyze-player.test.ts
@@ -1,0 +1,233 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type {
+  ChessComArchives,
+  ChessComMonthlyGames,
+  ChessComProfile,
+  ChessComStats,
+  ProviderResponse,
+  ProviderResponseMetadata
+} from "@chessinsights/chesscom-client";
+import type { ChessComImportClient, ImportProgressEvent } from "@chessinsights/importer";
+import { describe, expect, it } from "vitest";
+
+import { analyzeChessComPlayer } from "./index.js";
+
+const fixtureRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../tests/fixtures/chesscom");
+
+describe("analyzeChessComPlayer", () => {
+  it("imports a player through the injected client and returns dashboard-ready aggregates", async () => {
+    const client = createMockClient();
+    const events: ImportProgressEvent[] = [];
+
+    const analysis = await analyzeChessComPlayer(client, " TestUser ", {
+      onProgress(event) {
+        events.push(event);
+      }
+    });
+
+    expect(client.calls).toEqual([
+      "profile:testuser",
+      "stats:testuser",
+      "archives:testuser",
+      "monthly:testuser:2024:1",
+      "monthly:testuser:2024:2"
+    ]);
+    expect(events.map((event) => event.type)).toEqual([
+      "import_started",
+      "profile_fetched",
+      "stats_fetched",
+      "archives_listed",
+      "archive_fetched",
+      "archive_fetched",
+      "import_completed"
+    ]);
+    expect(analysis.username).toBe("testuser");
+    expect(analysis.profile.username).toBe("TestUser");
+    expect(analysis.importSummary).toEqual({
+      archiveCount: 2,
+      downloadedGameCount: 4,
+      normalizedGameCount: 3,
+      skippedArchiveUrls: ["https://api.chess.com/pub/player/otheruser/games/2024/03"],
+      skippedGameCount: 1
+    });
+    expect(analysis.defaultTimeClass).toBe("blitz");
+    expect(analysis.filters).toEqual({
+      opponentRatingBucketSize: 100,
+      openingLimit: 10,
+      ratingTimeClass: "blitz",
+      timeClass: null
+    });
+    expect(analysis.aggregates.results).toMatchObject({
+      total: 3,
+      win: 1,
+      loss: 1,
+      draw: 1,
+      percentages: {
+        win: 33.3,
+        loss: 33.3,
+        draw: 33.3
+      }
+    });
+    expect(analysis.aggregates.resultsByTimeClass.rapid).toMatchObject({
+      total: 1,
+      loss: 1
+    });
+    expect(analysis.aggregates.timeClasses).toEqual([
+      {
+        timeClass: "bullet",
+        total: 0,
+        percentage: 0
+      },
+      {
+        timeClass: "blitz",
+        total: 1,
+        percentage: 33.3
+      },
+      {
+        timeClass: "rapid",
+        total: 1,
+        percentage: 33.3
+      },
+      {
+        timeClass: "daily",
+        total: 1,
+        percentage: 33.3
+      }
+    ]);
+    expect(analysis.aggregates.ratingTimeline).toEqual({
+      timeClass: "blitz",
+      points: [
+        {
+          playedAt: "2024-01-15T08:26:40.000Z",
+          rating: 1350,
+          gameUrl: "https://www.chess.com/game/live/1001",
+          timeClass: "blitz"
+        }
+      ]
+    });
+    expect(analysis.aggregates.opponentRatingBuckets).toMatchObject({
+      skippedGames: 0,
+      buckets: [
+        {
+          label: "1200-1299",
+          counts: {
+            total: 1,
+            win: 1
+          }
+        },
+        {
+          label: "1400-1499",
+          counts: {
+            total: 2,
+            loss: 1,
+            draw: 1
+          }
+        }
+      ]
+    });
+    expect(analysis.aggregates.openingSummary.map((entry) => entry.openingFamily)).toEqual([
+      "Italian Game",
+      "Queen's Pawn Opening",
+      "Sicilian Defense"
+    ]);
+  });
+
+  it("supports time-class filters and explicit rating timelines", async () => {
+    const client = createMockClient();
+
+    const analysis = await analyzeChessComPlayer(client, "testuser", {
+      openingLimit: 1,
+      ratingTimeClass: "rapid",
+      timeClass: "rapid"
+    });
+
+    expect(analysis.filters).toEqual({
+      opponentRatingBucketSize: 100,
+      openingLimit: 1,
+      ratingTimeClass: "rapid",
+      timeClass: "rapid"
+    });
+    expect(analysis.aggregates.results).toMatchObject({
+      total: 1,
+      loss: 1
+    });
+    expect(analysis.aggregates.ratingTimeline.points).toEqual([
+      {
+        playedAt: "2024-01-16T18:44:11.000Z",
+        rating: 1402,
+        gameUrl: "https://www.chess.com/game/live/1002",
+        timeClass: "rapid"
+      }
+    ]);
+    expect(analysis.aggregates.openingSummary).toHaveLength(1);
+    expect(analysis.aggregates.openingSummary[0]?.openingFamily).toBe("Italian Game");
+  });
+});
+
+interface MockImportClient extends ChessComImportClient {
+  readonly calls: string[];
+}
+
+function createMockClient(): MockImportClient {
+  const profile = readFixture<ChessComProfile>("profile.json");
+  const stats = readFixture<ChessComStats>("stats.json");
+  const monthlyGames = readFixture<ChessComMonthlyGames>("monthly-games.json");
+  const emptyMonthlyGames: ChessComMonthlyGames = {
+    games: []
+  };
+  const archives: ChessComArchives = {
+    archives: [
+      "https://api.chess.com/pub/player/testuser/games/2024/01",
+      "https://api.chess.com/pub/player/testuser/games/2024/02",
+      "https://api.chess.com/pub/player/otheruser/games/2024/03"
+    ]
+  };
+  const calls: string[] = [];
+
+  return {
+    calls,
+    async getPlayerProfile(username) {
+      calls.push(`profile:${username}`);
+      return providerResponse(`https://api.chess.com/pub/player/${username}`, profile);
+    },
+    async getPlayerStats(username) {
+      calls.push(`stats:${username}`);
+      return providerResponse(`https://api.chess.com/pub/player/${username}/stats`, stats);
+    },
+    async getGameArchives(username) {
+      calls.push(`archives:${username}`);
+      return providerResponse(`https://api.chess.com/pub/player/${username}/games/archives`, archives);
+    },
+    async getMonthlyGames(username, year, month) {
+      calls.push(`monthly:${username}:${year}:${month}`);
+      const games = month === 1 ? monthlyGames : emptyMonthlyGames;
+
+      return providerResponse(`https://api.chess.com/pub/player/${username}/games/${year}/${month}`, games);
+    }
+  };
+}
+
+function readFixture<TFixture>(fileName: string): TFixture {
+  return JSON.parse(readFileSync(resolve(fixtureRoot, fileName), "utf8")) as TFixture;
+}
+
+function metadata(url: string): ProviderResponseMetadata {
+  return {
+    url,
+    etag: null,
+    lastModified: null,
+    cacheControl: null,
+    retryAfter: null
+  };
+}
+
+function providerResponse<TData>(url: string, data: TData): ProviderResponse<TData> {
+  return {
+    status: 200,
+    data,
+    metadata: metadata(url)
+  };
+}

--- a/packages/analysis/src/analyze-player.ts
+++ b/packages/analysis/src/analyze-player.ts
@@ -1,0 +1,107 @@
+import {
+  buildOpeningSummary,
+  buildOpponentRatingBuckets,
+  buildRatingTimeline,
+  buildResultBreakdown,
+  buildTimeClassBreakdown,
+  getMostPlayedTimeClass
+} from "@chessinsights/analytics";
+import type { TimeClass } from "@chessinsights/domain";
+import { importChessComPlayer } from "@chessinsights/importer";
+import type { ChessComImportClient, ChessComImportResult } from "@chessinsights/importer";
+
+import type { PlayerAnalysis, PlayerAnalysisOptions, ResultsByTimeClass } from "./types.js";
+
+const TIME_CLASSES: readonly TimeClass[] = ["bullet", "blitz", "rapid", "daily"];
+const DEFAULT_OPENING_LIMIT = 10;
+const DEFAULT_OPPONENT_RATING_BUCKET_SIZE = 100;
+type TimeClassOption = {
+  readonly timeClass?: TimeClass;
+};
+
+export async function analyzeChessComPlayer(
+  client: ChessComImportClient,
+  username: string,
+  options: PlayerAnalysisOptions = {}
+): Promise<PlayerAnalysis> {
+  const importOptions = options.onProgress === undefined ? {} : { onProgress: options.onProgress };
+  const importResult = await importChessComPlayer(client, username, importOptions);
+
+  return buildPlayerAnalysis(importResult, options);
+}
+
+export function buildPlayerAnalysis(
+  importResult: ChessComImportResult,
+  options: PlayerAnalysisOptions = {}
+): PlayerAnalysis {
+  const defaultTimeClass = getMostPlayedTimeClass(importResult.records);
+  const ratingTimeClass = options.ratingTimeClass ?? defaultTimeClass;
+  const openingLimit = options.openingLimit ?? DEFAULT_OPENING_LIMIT;
+  const opponentRatingBucketSize = options.opponentRatingBucketSize ?? DEFAULT_OPPONENT_RATING_BUCKET_SIZE;
+  const aggregateTimeClassOption = toTimeClassOption(options.timeClass);
+  const ratingTimeClassOption = toTimeClassOption(ratingTimeClass ?? undefined);
+  const downloadedGameCount = importResult.archives.reduce(
+    (currentTotal, archive) => currentTotal + archive.gameCount,
+    0
+  );
+
+  return {
+    username: importResult.username,
+    profile: importResult.profile,
+    stats: importResult.stats,
+    defaultTimeClass,
+    filters: {
+      timeClass: options.timeClass ?? null,
+      ratingTimeClass,
+      openingLimit,
+      opponentRatingBucketSize
+    },
+    importSummary: {
+      archiveCount: importResult.archives.length,
+      downloadedGameCount,
+      normalizedGameCount: importResult.records.length,
+      skippedGameCount: importResult.skippedGames,
+      skippedArchiveUrls: importResult.skippedArchiveUrls
+    },
+    aggregates: {
+      results: buildResultBreakdown(importResult.records, aggregateTimeClassOption),
+      resultsByTimeClass: buildResultsByTimeClass(importResult.records),
+      timeClasses: buildTimeClassBreakdown(importResult.records),
+      ratingTimeline: {
+        timeClass: ratingTimeClass,
+        points: buildRatingTimeline(importResult.records, ratingTimeClassOption)
+      },
+      opponentRatingBuckets: buildOpponentRatingBuckets(importResult.records, {
+        bucketSize: opponentRatingBucketSize,
+        ...aggregateTimeClassOption
+      }),
+      openingSummary: buildOpeningSummary(importResult.records, {
+        limit: openingLimit,
+        ...aggregateTimeClassOption
+      })
+    }
+  };
+}
+
+function toTimeClassOption(timeClass: TimeClass | undefined): TimeClassOption {
+  return timeClass === undefined ? {} : { timeClass };
+}
+
+function buildResultsByTimeClass(records: ChessComImportResult["records"]): ResultsByTimeClass {
+  return {
+    bullet: buildResultBreakdown(records, {
+      timeClass: "bullet"
+    }),
+    blitz: buildResultBreakdown(records, {
+      timeClass: "blitz"
+    }),
+    rapid: buildResultBreakdown(records, {
+      timeClass: "rapid"
+    }),
+    daily: buildResultBreakdown(records, {
+      timeClass: "daily"
+    })
+  };
+}
+
+export const SUPPORTED_TIME_CLASSES = TIME_CLASSES;

--- a/packages/analysis/src/index.ts
+++ b/packages/analysis/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./analyze-player.js";
+export * from "./types.js";

--- a/packages/analysis/src/types.ts
+++ b/packages/analysis/src/types.ts
@@ -1,0 +1,64 @@
+import type {
+  OpeningSummaryEntry,
+  OpponentRatingBucketsResult,
+  RatingTimelinePoint,
+  ResultBreakdown,
+  TimeClassBreakdownEntry
+} from "@chessinsights/analytics";
+import type { TimeClass } from "@chessinsights/domain";
+import type {
+  ChessComImportResult,
+  ChessComProfile,
+  ChessComStats,
+  ImportOptions
+} from "@chessinsights/importer";
+
+export interface PlayerAnalysisOptions extends ImportOptions {
+  readonly openingLimit?: number;
+  readonly opponentRatingBucketSize?: number;
+  readonly ratingTimeClass?: TimeClass;
+  readonly timeClass?: TimeClass;
+}
+
+export type ResultsByTimeClass = Record<TimeClass, ResultBreakdown>;
+
+export interface PlayerAnalysisFilters {
+  readonly openingLimit: number;
+  readonly opponentRatingBucketSize: number;
+  readonly ratingTimeClass: TimeClass | null;
+  readonly timeClass: TimeClass | null;
+}
+
+export interface PlayerImportSummary {
+  readonly archiveCount: number;
+  readonly downloadedGameCount: number;
+  readonly normalizedGameCount: number;
+  readonly skippedArchiveUrls: readonly string[];
+  readonly skippedGameCount: number;
+}
+
+export interface RatingTimelineAnalysis {
+  readonly timeClass: TimeClass | null;
+  readonly points: readonly RatingTimelinePoint[];
+}
+
+export interface PlayerAnalysisAggregates {
+  readonly openingSummary: readonly OpeningSummaryEntry[];
+  readonly opponentRatingBuckets: OpponentRatingBucketsResult;
+  readonly ratingTimeline: RatingTimelineAnalysis;
+  readonly results: ResultBreakdown;
+  readonly resultsByTimeClass: ResultsByTimeClass;
+  readonly timeClasses: readonly TimeClassBreakdownEntry[];
+}
+
+export interface PlayerAnalysis {
+  readonly username: string;
+  readonly profile: ChessComProfile;
+  readonly stats: ChessComStats;
+  readonly defaultTimeClass: TimeClass | null;
+  readonly filters: PlayerAnalysisFilters;
+  readonly importSummary: PlayerImportSummary;
+  readonly aggregates: PlayerAnalysisAggregates;
+}
+
+export type PlayerAnalysisSource = ChessComImportResult;


### PR DESCRIPTION
## Summary

Adds the dashboard analysis service package. Closes #12.

This introduces `@chessinsights/analysis`, which composes the existing Chess.com importer and analytics package into one explicit read model for the future web/API layer. The service accepts an injected Chess.com import client, preserves importer progress events, and returns import summary metadata plus result, time-class, rating timeline, opponent-rating bucket, and opening aggregates.

## Changed files

- `packages/analysis/src/analyze-player.ts`: imports a player through the existing importer and builds the dashboard-ready aggregate model.
- `packages/analysis/src/types.ts`: explicit read-model and option types for future route handlers/UI.
- `packages/analysis/src/analyze-player.test.ts`: fixture-backed mocked-client tests for the default analysis and filtered views.
- `packages/analysis/package.json`, `package-lock.json`: workspace package wiring.

## Validation

- [x] Relevant tests run
- [x] Lint ran, if applicable
- [x] Typecheck ran, if applicable
- [ ] Build ran for user-visible web changes, if applicable
- [x] Behavior changes include or update regression tests
- [x] PR summary explains changed files and test results

Commands run:

```text
npm install
npm run lint
npm run typecheck
npm run test
npm run db:validate
npm audit --audit-level=moderate
git diff --check
```

Commands not run / reason:

```text
npm run build - no build script exists and this PR does not add user-visible web code.
Live Chess.com calls - not needed; tests use committed fixtures and an injected mock client.
Live database/queue checks - not touched in this composition-only PR.
```

## Risk / rollout

- [x] No provider, scraper, queue, or rate-limit behavior changed
- [x] No database schema or migration changed
- [x] No user-visible behavior changed
- [x] Rollback or follow-up plan is documented below, if needed

Notes:

This package composes existing behavior only. The high-risk Chess.com provider/import sequence is still owned by `@chessinsights/importer`, and the tests confirm the service uses the injected client with fixtures rather than live provider calls.

Follow-up work should wire this read model into a Next.js route or worker-backed API once the web app shell lands.

## CodeRabbit follow-up

None yet; this is the initial review for the PR.
