### PR TITLE
Align dashboard with target insight views

### DIFF
--- a/apps/web/app/components/analyze-dashboard.test.ts
+++ b/apps/web/app/components/analyze-dashboard.test.ts
@@ -89,8 +89,30 @@ describe("AnalyzeDashboard", () => {
     });
 
     expect(blitzButton.getAttribute("aria-pressed")).toBe("true");
-    expect(fetchMock.mock.calls[1]?.[0].toString()).toBe("/api/analyze?username=testuser&timeClass=blitz");
+    expect(fetchMock.mock.calls[1]?.[0].toString()).toBe(
+      "/api/analyze?username=testuser&timeClass=blitz&ratingTimeClass=blitz"
+    );
     expect(await screen.findByText("testuser-blitz")).toBeTruthy();
+  });
+
+  it("refetches opening summaries with the selected player color", async () => {
+    const fetchMock = stubFetch();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ analysis: makeAnalysis("testuser") }));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ analysis: makeAnalysis("testuser-white") }));
+
+    render(createElement(AnalyzeDashboard));
+    submitUsername("testuser");
+
+    expect(await screen.findByText("testuser")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "white" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(fetchMock.mock.calls[1]?.[0].toString()).toBe("/api/analyze?username=testuser&openingPlayerColor=white");
+    expect(await screen.findByText("testuser-white")).toBeTruthy();
   });
 });
 
@@ -167,6 +189,7 @@ function makeAnalysis(username: string): PlayerAnalysis {
     filters: {
       timeClass: null,
       ratingTimeClass: "blitz",
+      openingPlayerColor: null,
       openingLimit: 10,
       opponentRatingBucketSize: 100
     },
@@ -178,6 +201,12 @@ function makeAnalysis(username: string): PlayerAnalysis {
       skippedGameCount: 0
     },
     aggregates: {
+      summary: {
+        totalGames: 3,
+        results: resultBreakdown,
+        estimatedTimePlayedSeconds: 900,
+        skippedEstimatedTimeGames: 0
+      },
       results: resultBreakdown,
       resultsByTimeClass: {
         bullet: emptyResultBreakdown,
@@ -198,6 +227,7 @@ function makeAnalysis(username: string): PlayerAnalysis {
           {
             playedAt: "2024-01-01T00:00:00.000Z",
             rating: 1500,
+            result: "win",
             gameUrl: "https://www.chess.com/game/live/1",
             timeClass: "blitz"
           }
@@ -221,7 +251,33 @@ function makeAnalysis(username: string): PlayerAnalysis {
           counts: resultBreakdown,
           percentages: resultBreakdown.percentages
         }
-      ]
+      ],
+      endingBreakdowns: {
+        wonBy: [
+          {
+            ending: "resignation",
+            label: "Resignation",
+            count: 1,
+            percentage: 100
+          }
+        ],
+        lostBy: [
+          {
+            ending: "checkmate",
+            label: "Checkmate",
+            count: 1,
+            percentage: 100
+          }
+        ],
+        drawnBy: [
+          {
+            ending: "stalemate",
+            label: "Stalemate",
+            count: 1,
+            percentage: 100
+          }
+        ]
+      }
     }
   };
 }

--- a/apps/web/app/components/analyze-dashboard.test.ts
+++ b/apps/web/app/components/analyze-dashboard.test.ts
@@ -81,6 +81,12 @@ describe("AnalyzeDashboard", () => {
 
     expect(await screen.findByText("testuser")).toBeTruthy();
 
+    fireEvent.change(screen.getByLabelText("Chess.com username"), {
+      target: {
+        value: "otheruser"
+      }
+    });
+
     const blitzButton = screen.getByRole("button", { name: "blitz" });
     fireEvent.click(blitzButton);
 

--- a/apps/web/app/components/analyze-dashboard.test.ts
+++ b/apps/web/app/components/analyze-dashboard.test.ts
@@ -90,7 +90,7 @@ describe("AnalyzeDashboard", () => {
 
     expect(blitzButton.getAttribute("aria-pressed")).toBe("true");
     expect(fetchMock.mock.calls[1]?.[0].toString()).toBe(
-      "/api/analyze?username=testuser&timeClass=blitz&ratingTimeClass=blitz"
+      "/api/analyze?username=testuser&ratingTimeClass=blitz&timeClass=blitz"
     );
     expect(await screen.findByText("testuser-blitz")).toBeTruthy();
   });
@@ -111,7 +111,9 @@ describe("AnalyzeDashboard", () => {
       expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
-    expect(fetchMock.mock.calls[1]?.[0].toString()).toBe("/api/analyze?username=testuser&openingPlayerColor=white");
+    expect(fetchMock.mock.calls[1]?.[0].toString()).toBe(
+      "/api/analyze?username=testuser&ratingTimeClass=all&openingPlayerColor=white"
+    );
     expect(await screen.findByText("testuser-white")).toBeTruthy();
   });
 });

--- a/apps/web/app/components/analyze-dashboard.tsx
+++ b/apps/web/app/components/analyze-dashboard.tsx
@@ -10,7 +10,7 @@ import type {
 import type { PlayerAnalysis } from "@chessinsights/analysis";
 import type { PlayerColor, TimeClass } from "@chessinsights/domain";
 import type { FormEvent, PointerEvent } from "react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 type TimeClassFilter = TimeClass | "all";
 type PlayerColorFilter = PlayerColor | "all";
@@ -43,6 +43,7 @@ export function AnalyzeDashboard() {
   const [username, setUsername] = useState("");
   const [activeTimeClass, setActiveTimeClass] = useState<TimeClassFilter>("all");
   const [activeOpeningPlayerColor, setActiveOpeningPlayerColor] = useState<PlayerColorFilter>("all");
+  const [analyzedUsername, setAnalyzedUsername] = useState<string | null>(null);
   const [analysis, setAnalysis] = useState<PlayerAnalysis | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -52,11 +53,13 @@ export function AnalyzeDashboard() {
 
   async function submitAnalysis(
     nextTimeClass: TimeClassFilter = activeTimeClass,
-    nextOpeningPlayerColor: PlayerColorFilter = activeOpeningPlayerColor
+    nextOpeningPlayerColor: PlayerColorFilter = activeOpeningPlayerColor,
+    targetUsername = username
   ) {
-    const trimmedUsername = username.trim();
+    const trimmedUsername = targetUsername.trim();
 
     if (trimmedUsername.length === 0) {
+      setAnalyzedUsername(null);
       setAnalysis(null);
       setErrorMessage("Enter a Chess.com username.");
       return;
@@ -91,7 +94,9 @@ export function AnalyzeDashboard() {
       }
 
       setAnalysis(payload.analysis);
+      setAnalyzedUsername(payload.analysis.username);
     } catch (error) {
+      setAnalyzedUsername(null);
       setAnalysis(null);
       setErrorMessage(error instanceof Error ? error.message : "Analysis failed.");
     } finally {
@@ -107,16 +112,16 @@ export function AnalyzeDashboard() {
   function selectTimeClass(timeClass: TimeClassFilter) {
     setActiveTimeClass(timeClass);
 
-    if (hasAnalysis) {
-      void submitAnalysis(timeClass, activeOpeningPlayerColor);
+    if (hasAnalysis && analyzedUsername !== null) {
+      void submitAnalysis(timeClass, activeOpeningPlayerColor, analyzedUsername);
     }
   }
 
   function selectOpeningPlayerColor(playerColor: PlayerColorFilter) {
     setActiveOpeningPlayerColor(playerColor);
 
-    if (hasAnalysis) {
-      void submitAnalysis(activeTimeClass, playerColor);
+    if (hasAnalysis && analyzedUsername !== null) {
+      void submitAnalysis(activeTimeClass, playerColor, analyzedUsername);
     }
   }
 
@@ -269,16 +274,23 @@ function RatingLineChart({ points }: { readonly points: readonly RatingTimelineP
   const normalizedZoomRange = normalizeZoomRange(zoomRange, points.length);
   const visiblePoints =
     normalizedZoomRange === null ? points : points.slice(normalizedZoomRange.start, normalizedZoomRange.end + 1);
+  const zoomStartOffset = normalizedZoomRange?.start ?? 0;
   const chartPoints = useMemo(() => buildRatingChartPoints(visiblePoints), [visiblePoints]);
   const path = chartPoints.map((point) => `${point.x},${point.y}`).join(" ");
-  const brush = buildBrush(dragStart, dragEnd, points.length);
+  const brush = buildBrush(dragStart, dragEnd, visiblePoints.length);
+
+  useEffect(() => {
+    setZoomRange(null);
+    setDragStart(null);
+    setDragEnd(null);
+  }, [points]);
 
   function handlePointerDown(event: PointerEvent<SVGSVGElement>) {
-    if (points.length < 2) {
+    if (visiblePoints.length < 2) {
       return;
     }
 
-    const index = indexFromPointer(event, points.length);
+    const index = indexFromPointer(event, visiblePoints.length);
     setDragStart(index);
     setDragEnd(index);
     event.currentTarget.setPointerCapture(event.pointerId);
@@ -289,7 +301,7 @@ function RatingLineChart({ points }: { readonly points: readonly RatingTimelineP
       return;
     }
 
-    setDragEnd(indexFromPointer(event, points.length));
+    setDragEnd(indexFromPointer(event, visiblePoints.length));
   }
 
   function handlePointerUp(event: PointerEvent<SVGSVGElement>) {
@@ -303,7 +315,10 @@ function RatingLineChart({ points }: { readonly points: readonly RatingTimelineP
     const end = Math.max(dragStart, dragEnd);
 
     if (end - start >= 1) {
-      setZoomRange({ start, end });
+      setZoomRange({
+        start: zoomStartOffset + start,
+        end: zoomStartOffset + end
+      });
     }
 
     setDragStart(null);

--- a/apps/web/app/components/analyze-dashboard.tsx
+++ b/apps/web/app/components/analyze-dashboard.tsx
@@ -71,9 +71,10 @@ export function AnalyzeDashboard() {
         username: trimmedUsername
       });
 
+      params.set("ratingTimeClass", nextTimeClass);
+
       if (nextTimeClass !== "all") {
         params.set("timeClass", nextTimeClass);
-        params.set("ratingTimeClass", nextTimeClass);
       }
 
       if (nextOpeningPlayerColor !== "all") {
@@ -518,9 +519,9 @@ function DonutChart({ entries }: { readonly entries: readonly EndingBreakdownEnt
         </text>
       </svg>
       <div className="donut-legend">
-        {entries.map((entry, index) => (
+        {entries.map((entry) => (
           <div key={entry.ending} className="legend-row">
-            <span style={{ background: DONUT_COLORS[index % DONUT_COLORS.length] }} />
+            <span style={{ background: donutLegendColor(entry, positiveEntries) }} />
             <small>{entry.label}</small>
             <strong>{formatInteger(entry.count)}</strong>
           </div>
@@ -528,6 +529,15 @@ function DonutChart({ entries }: { readonly entries: readonly EndingBreakdownEnt
       </div>
     </div>
   );
+}
+
+function donutLegendColor(
+  entry: EndingBreakdownEntry,
+  positiveEntries: readonly EndingBreakdownEntry[]
+): string {
+  const segmentIndex = positiveEntries.findIndex((positiveEntry) => positiveEntry.ending === entry.ending);
+
+  return segmentIndex === -1 ? "#e5ebe2" : (DONUT_COLORS[segmentIndex % DONUT_COLORS.length] ?? "#e5ebe2");
 }
 
 function PanelHeader({ title, value }: { readonly title: string; readonly value: string }) {

--- a/apps/web/app/components/analyze-dashboard.tsx
+++ b/apps/web/app/components/analyze-dashboard.tsx
@@ -1,18 +1,19 @@
 "use client";
 
 import type {
+  EndingBreakdownEntry,
   OpeningSummaryEntry,
   OpponentRatingBucket,
   RatingTimelinePoint,
-  ResultBreakdown,
-  TimeClassBreakdownEntry
+  ResultBreakdown
 } from "@chessinsights/analytics";
 import type { PlayerAnalysis } from "@chessinsights/analysis";
-import type { TimeClass } from "@chessinsights/domain";
-import type { FormEvent } from "react";
+import type { PlayerColor, TimeClass } from "@chessinsights/domain";
+import type { FormEvent, PointerEvent } from "react";
 import { useMemo, useState } from "react";
 
 type TimeClassFilter = TimeClass | "all";
+type PlayerColorFilter = PlayerColor | "all";
 
 interface AnalyzeApiResponse {
   readonly analysis?: PlayerAnalysis;
@@ -22,19 +23,37 @@ interface AnalyzeApiResponse {
   };
 }
 
+interface ChartPoint {
+  readonly x: number;
+  readonly y: number;
+  readonly point: RatingTimelinePoint;
+}
+
+interface ZoomRange {
+  readonly start: number;
+  readonly end: number;
+}
+
 const TIME_CLASS_FILTERS: readonly TimeClassFilter[] = ["all", "bullet", "blitz", "rapid", "daily"];
+const OPENING_COLOR_FILTERS: readonly PlayerColorFilter[] = ["all", "white", "black"];
+const NUMBER_FORMAT = new Intl.NumberFormat("en-US");
+const DONUT_COLORS: readonly string[] = ["#21735f", "#3768a6", "#b7822d", "#8a7f6a", "#b94a48", "#5d6b99", "#925a39"];
 
 export function AnalyzeDashboard() {
   const [username, setUsername] = useState("");
   const [activeTimeClass, setActiveTimeClass] = useState<TimeClassFilter>("all");
+  const [activeOpeningPlayerColor, setActiveOpeningPlayerColor] = useState<PlayerColorFilter>("all");
   const [analysis, setAnalysis] = useState<PlayerAnalysis | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
   const hasAnalysis = analysis !== null;
-  const activeResults = analysis?.aggregates.results ?? emptyResultBreakdown();
+  const activeResults = analysis?.aggregates.summary.results ?? emptyResultBreakdown();
 
-  async function submitAnalysis(nextTimeClass: TimeClassFilter = activeTimeClass) {
+  async function submitAnalysis(
+    nextTimeClass: TimeClassFilter = activeTimeClass,
+    nextOpeningPlayerColor: PlayerColorFilter = activeOpeningPlayerColor
+  ) {
     const trimmedUsername = username.trim();
 
     if (trimmedUsername.length === 0) {
@@ -54,6 +73,11 @@ export function AnalyzeDashboard() {
 
       if (nextTimeClass !== "all") {
         params.set("timeClass", nextTimeClass);
+        params.set("ratingTimeClass", nextTimeClass);
+      }
+
+      if (nextOpeningPlayerColor !== "all") {
+        params.set("openingPlayerColor", nextOpeningPlayerColor);
       }
 
       const response = await fetch(`/api/analyze?${params.toString()}`, {
@@ -83,7 +107,15 @@ export function AnalyzeDashboard() {
     setActiveTimeClass(timeClass);
 
     if (hasAnalysis) {
-      void submitAnalysis(timeClass);
+      void submitAnalysis(timeClass, activeOpeningPlayerColor);
+    }
+  }
+
+  function selectOpeningPlayerColor(playerColor: PlayerColorFilter) {
+    setActiveOpeningPlayerColor(playerColor);
+
+    if (hasAnalysis) {
+      void submitAnalysis(activeTimeClass, playerColor);
     }
   }
 
@@ -105,7 +137,7 @@ export function AnalyzeDashboard() {
               id="username"
               name="username"
               autoComplete="off"
-              placeholder="hikaru"
+              placeholder="zac_88"
               value={username}
               onChange={(event) => setUsername(event.target.value)}
             />
@@ -116,36 +148,33 @@ export function AnalyzeDashboard() {
         </form>
       </section>
 
-      <section className="toolbar" aria-label="Analysis filters">
-        <div className="segmented-control" role="group" aria-label="Time class">
-          {TIME_CLASS_FILTERS.map((timeClass) => (
-            <button
-              key={timeClass}
-              type="button"
-              aria-pressed={activeTimeClass === timeClass}
-              onClick={() => selectTimeClass(timeClass)}
-              disabled={isLoading}
-            >
-              {timeClass}
-            </button>
-          ))}
-        </div>
-        <div className="status-pill">{statusLabel(isLoading, analysis, errorMessage)}</div>
-      </section>
-
       {errorMessage === null ? null : (
         <section className="error-panel" role="alert">
           {errorMessage}
         </section>
       )}
 
+      <PlayerSummaryPanel
+        analysis={analysis}
+        results={activeResults}
+        activeTimeClass={activeTimeClass}
+        isLoading={isLoading}
+        errorMessage={errorMessage}
+        onSelectTimeClass={selectTimeClass}
+      />
+
       <section className="dashboard-grid" aria-label="Analysis dashboard">
-        <ResultPanel results={activeResults} />
-        <TimeClassPanel entries={analysis?.aggregates.timeClasses ?? []} />
         <RatingPanel points={analysis?.aggregates.ratingTimeline.points ?? []} />
+        <OpeningsPanel
+          openings={analysis?.aggregates.openingSummary ?? []}
+          activePlayerColor={activeOpeningPlayerColor}
+          isLoading={isLoading}
+          onSelectPlayerColor={selectOpeningPlayerColor}
+        />
         <OpponentBucketsPanel buckets={analysis?.aggregates.opponentRatingBuckets.buckets ?? []} />
-        <OpeningsPanel openings={analysis?.aggregates.openingSummary ?? []} />
-        <ImportPanel analysis={analysis} />
+        <EndingPanel title="Games Won By" entries={analysis?.aggregates.endingBreakdowns.wonBy ?? []} />
+        <EndingPanel title="Games Lost By" entries={analysis?.aggregates.endingBreakdowns.lostBy ?? []} />
+        <EndingPanel title="Games Drawn By" entries={analysis?.aggregates.endingBreakdowns.drawnBy ?? []} />
       </section>
     </main>
   );
@@ -161,104 +190,343 @@ function ChessboardMark() {
   );
 }
 
-function ResultPanel({ results }: { readonly results: ResultBreakdown }) {
-  return (
-    <article className="panel">
-      <PanelHeader title="Results" value={`${results.total} games`} />
-      <StackedResultBar results={results} />
-      <div className="result-metrics">
-        <Metric label="Wins" value={`${results.percentages.win}%`} />
-        <Metric label="Losses" value={`${results.percentages.loss}%`} />
-        <Metric label="Draws" value={`${results.percentages.draw}%`} />
-      </div>
-    </article>
-  );
-}
+function PlayerSummaryPanel({
+  analysis,
+  results,
+  activeTimeClass,
+  isLoading,
+  errorMessage,
+  onSelectTimeClass
+}: {
+  readonly analysis: PlayerAnalysis | null;
+  readonly results: ResultBreakdown;
+  readonly activeTimeClass: TimeClassFilter;
+  readonly isLoading: boolean;
+  readonly errorMessage: string | null;
+  readonly onSelectTimeClass: (timeClass: TimeClassFilter) => void;
+}) {
+  const summary = analysis?.aggregates.summary;
+  const totalGames = summary?.totalGames ?? results.total;
+  const estimatedTimePlayedSeconds = summary?.estimatedTimePlayedSeconds ?? 0;
+  const skippedEstimatedTimeGames = summary?.skippedEstimatedTimeGames ?? 0;
 
-function TimeClassPanel({ entries }: { readonly entries: readonly TimeClassBreakdownEntry[] }) {
   return (
-    <article className="panel">
-      <PanelHeader title="Time Classes" value={`${entries.reduce((total, entry) => total + entry.total, 0)} games`} />
-      <div className="row-list">
-        {entries.length === 0
-          ? emptyRows(["bullet", "blitz", "rapid", "daily"])
-          : entries.map((entry) => (
-              <BarRow
-                key={entry.timeClass}
-                label={entry.timeClass}
-                value={`${entry.total}`}
-                percentage={entry.percentage}
-              />
-            ))}
+    <section className="summary-panel" aria-label="Player summary">
+      <div className="summary-heading">
+        <div>
+          <p className="eyebrow">Player Summary</p>
+          <h2>{analysis?.username ?? "No player"}</h2>
+        </div>
+        <div className="status-pill">{statusLabel(isLoading, analysis, errorMessage)}</div>
       </div>
-    </article>
+
+      <div className="summary-stats">
+        <Metric label="Total games" value={formatInteger(totalGames)} />
+        <Metric
+          label="Time played"
+          value={formatDuration(estimatedTimePlayedSeconds)}
+          title={
+            skippedEstimatedTimeGames === 0
+              ? "Estimated from Chess.com time controls."
+              : `Estimated from Chess.com time controls; ${skippedEstimatedTimeGames} games had no live clock estimate.`
+          }
+        />
+      </div>
+
+      <StackedResultBar results={results} />
+
+      <div className="result-metrics">
+        <ResultMetric label="Wins" result="win" count={results.win} percentage={results.percentages.win} />
+        <ResultMetric label="Draws" result="draw" count={results.draw} percentage={results.percentages.draw} />
+        <ResultMetric label="Losses" result="loss" count={results.loss} percentage={results.percentages.loss} />
+      </div>
+
+      <SegmentedControl
+        label="Time class"
+        values={TIME_CLASS_FILTERS}
+        activeValue={activeTimeClass}
+        disabled={isLoading}
+        onSelect={onSelectTimeClass}
+      />
+    </section>
   );
 }
 
 function RatingPanel({ points }: { readonly points: readonly RatingTimelinePoint[] }) {
   return (
-    <article className="panel wide-panel">
-      <PanelHeader title="Rating Timeline" value={points.length === 0 ? "0 points" : `${points.length} points`} />
-      <RatingSparkline points={points} />
+    <article className="panel full-panel">
+      <PanelHeader title="ELO Over Time" value={points.length === 0 ? "0 games" : `${formatInteger(points.length)} games`} />
+      <RatingLineChart points={points} />
     </article>
+  );
+}
+
+function RatingLineChart({ points }: { readonly points: readonly RatingTimelinePoint[] }) {
+  const [zoomRange, setZoomRange] = useState<ZoomRange | null>(null);
+  const [dragStart, setDragStart] = useState<number | null>(null);
+  const [dragEnd, setDragEnd] = useState<number | null>(null);
+  const normalizedZoomRange = normalizeZoomRange(zoomRange, points.length);
+  const visiblePoints =
+    normalizedZoomRange === null ? points : points.slice(normalizedZoomRange.start, normalizedZoomRange.end + 1);
+  const chartPoints = useMemo(() => buildRatingChartPoints(visiblePoints), [visiblePoints]);
+  const path = chartPoints.map((point) => `${point.x},${point.y}`).join(" ");
+  const brush = buildBrush(dragStart, dragEnd, points.length);
+
+  function handlePointerDown(event: PointerEvent<SVGSVGElement>) {
+    if (points.length < 2) {
+      return;
+    }
+
+    const index = indexFromPointer(event, points.length);
+    setDragStart(index);
+    setDragEnd(index);
+    event.currentTarget.setPointerCapture(event.pointerId);
+  }
+
+  function handlePointerMove(event: PointerEvent<SVGSVGElement>) {
+    if (dragStart === null) {
+      return;
+    }
+
+    setDragEnd(indexFromPointer(event, points.length));
+  }
+
+  function handlePointerUp(event: PointerEvent<SVGSVGElement>) {
+    if (dragStart === null || dragEnd === null) {
+      setDragStart(null);
+      setDragEnd(null);
+      return;
+    }
+
+    const start = Math.min(dragStart, dragEnd);
+    const end = Math.max(dragStart, dragEnd);
+
+    if (end - start >= 1) {
+      setZoomRange({ start, end });
+    }
+
+    setDragStart(null);
+    setDragEnd(null);
+    event.currentTarget.releasePointerCapture(event.pointerId);
+  }
+
+  if (points.length === 0) {
+    return <div className="chart-empty">No rating data</div>;
+  }
+
+  return (
+    <div className="rating-chart-frame">
+      <svg
+        viewBox="0 0 100 56"
+        role="img"
+        aria-label="ELO rating timeline"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={() => {
+          setDragStart(null);
+          setDragEnd(null);
+        }}
+      >
+        <g className="chart-grid" aria-hidden="true">
+          <line x1="6" x2="96" y1="8" y2="8" />
+          <line x1="6" x2="96" y1="26" y2="26" />
+          <line x1="6" x2="96" y1="44" y2="44" />
+        </g>
+        <polyline points={path} fill="none" className="rating-line" vectorEffect="non-scaling-stroke" />
+        {chartPoints.map((chartPoint) => (
+          <a
+            key={`${chartPoint.point.gameUrl}-${chartPoint.point.playedAt}`}
+            href={chartPoint.point.gameUrl}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <circle
+              className={`rating-point ${chartPoint.point.result}`}
+              cx={chartPoint.x}
+              cy={chartPoint.y}
+              r="1.65"
+            />
+            <title>
+              {`${formatInteger(chartPoint.point.rating)} ELO, ${chartPoint.point.result}, ${formatDate(chartPoint.point.playedAt)}`}
+            </title>
+          </a>
+        ))}
+        {brush === null ? null : <rect className="zoom-brush" x={brush.x} y="6" width={brush.width} height="40" />}
+      </svg>
+      <div className="chart-axis">
+        <span>{formatDate(visiblePoints[0]?.playedAt)}</span>
+        <span>{ratingRangeLabel(visiblePoints)}</span>
+        <span>{formatDate(visiblePoints.at(-1)?.playedAt)}</span>
+      </div>
+      {normalizedZoomRange === null ? null : (
+        <button className="text-button" type="button" onClick={() => setZoomRange(null)}>
+          Reset zoom
+        </button>
+      )}
+    </div>
+  );
+}
+
+function OpeningsPanel({
+  openings,
+  activePlayerColor,
+  isLoading,
+  onSelectPlayerColor
+}: {
+  readonly openings: readonly OpeningSummaryEntry[];
+  readonly activePlayerColor: PlayerColorFilter;
+  readonly isLoading: boolean;
+  readonly onSelectPlayerColor: (playerColor: PlayerColorFilter) => void;
+}) {
+  return (
+    <article className="panel wide-panel">
+      <PanelHeader title="Top Openings" value={`${formatInteger(openings.length)} openings`} />
+      <SegmentedControl
+        label="Opening color perspective"
+        values={OPENING_COLOR_FILTERS}
+        activeValue={activePlayerColor}
+        disabled={isLoading}
+        onSelect={onSelectPlayerColor}
+      />
+      <OpeningBarChart openings={openings} />
+    </article>
+  );
+}
+
+function OpeningBarChart({ openings }: { readonly openings: readonly OpeningSummaryEntry[] }) {
+  const maxTotal = Math.max(1, ...openings.map((opening) => opening.counts.total));
+
+  if (openings.length === 0) {
+    return <div className="chart-empty">No opening data</div>;
+  }
+
+  return (
+    <div className="vertical-chart opening-chart" aria-label="Top openings stacked by result">
+      {openings.map((opening) => (
+        <StackedVerticalBar
+          key={opening.openingFamily}
+          label={opening.openingFamily}
+          total={opening.counts.total}
+          maxTotal={maxTotal}
+          results={{ ...opening.counts, percentages: opening.percentages }}
+        />
+      ))}
+    </div>
   );
 }
 
 function OpponentBucketsPanel({ buckets }: { readonly buckets: readonly OpponentRatingBucket[] }) {
-  const maxTotal = Math.max(1, ...buckets.map((bucket) => bucket.counts.total));
-
-  return (
-    <article className="panel">
-      <PanelHeader title="Opponent Ratings" value={`${buckets.length} ranges`} />
-      <div className="row-list">
-        {buckets.length === 0
-          ? emptyRows(["1200-1299", "1300-1399", "1400-1499"])
-          : buckets.map((bucket) => (
-              <BarRow
-                key={bucket.label}
-                label={bucket.label}
-                value={`${bucket.counts.win}/${bucket.counts.loss}/${bucket.counts.draw}`}
-                percentage={(bucket.counts.total / maxTotal) * 100}
-              />
-            ))}
-      </div>
-    </article>
-  );
-}
-
-function OpeningsPanel({ openings }: { readonly openings: readonly OpeningSummaryEntry[] }) {
   return (
     <article className="panel wide-panel">
-      <PanelHeader title="Openings" value={`${openings.length} families`} />
-      <div className="opening-list">
-        {openings.length === 0
-          ? emptyRows(["Sicilian Defense", "Italian Game", "Queen's Pawn Opening"])
-          : openings.map((opening) => (
-              <div className="opening-row" key={opening.openingFamily}>
-                <div className="opening-meta">
-                  <span>{opening.openingFamily}</span>
-                  <span>{opening.counts.total}</span>
-                </div>
-                <StackedResultBar results={{ ...opening.counts, percentages: opening.percentages }} />
-              </div>
-            ))}
-      </div>
+      <PanelHeader title="Result by Opponent Rating" value={`${formatInteger(buckets.length)} ranges`} />
+      {buckets.length === 0 ? (
+        <div className="chart-empty">No opponent rating data</div>
+      ) : (
+        <div className="vertical-chart bucket-chart" aria-label="Opponent rating ranges stacked by result percentage">
+          {buckets.map((bucket) => (
+            <StackedVerticalBar
+              key={bucket.label}
+              label={bucket.label}
+              total={bucket.counts.total}
+              maxTotal={bucket.counts.total}
+              results={{ ...bucket.counts, percentages: bucket.percentages }}
+              normalized
+            />
+          ))}
+        </div>
+      )}
     </article>
   );
 }
 
-function ImportPanel({ analysis }: { readonly analysis: PlayerAnalysis | null }) {
-  const summary = analysis?.importSummary;
+function StackedVerticalBar({
+  label,
+  total,
+  maxTotal,
+  results,
+  normalized = false
+}: {
+  readonly label: string;
+  readonly total: number;
+  readonly maxTotal: number;
+  readonly results: ResultBreakdown;
+  readonly normalized?: boolean;
+}) {
+  const height = normalized ? 100 : Math.max(8, (total / maxTotal) * 100);
+
+  return (
+    <div className="vertical-bar-item">
+      <div className="vertical-bar-shell">
+        <div className="vertical-bar-stack" style={{ height: `${height}%` }}>
+          <span className="wins" style={{ height: `${results.percentages.win}%` }} title={`${results.win} wins`} />
+          <span className="draws" style={{ height: `${results.percentages.draw}%` }} title={`${results.draw} draws`} />
+          <span className="losses" style={{ height: `${results.percentages.loss}%` }} title={`${results.loss} losses`} />
+        </div>
+      </div>
+      <strong>{formatInteger(total)}</strong>
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function EndingPanel({ title, entries }: { readonly title: string; readonly entries: readonly EndingBreakdownEntry[] }) {
+  const total = entries.reduce((currentTotal, entry) => currentTotal + entry.count, 0);
 
   return (
     <article className="panel">
-      <PanelHeader title="Import" value={analysis?.username ?? "No player"} />
-      <div className="result-metrics import-metrics">
-        <Metric label="Archives" value={`${summary?.archiveCount ?? 0}`} />
-        <Metric label="Downloaded" value={`${summary?.downloadedGameCount ?? 0}`} />
-        <Metric label="Skipped" value={`${summary?.skippedGameCount ?? 0}`} />
-      </div>
+      <PanelHeader title={title} value={`${formatInteger(total)} games`} />
+      <DonutChart entries={entries} />
     </article>
+  );
+}
+
+function DonutChart({ entries }: { readonly entries: readonly EndingBreakdownEntry[] }) {
+  const total = entries.reduce((currentTotal, entry) => currentTotal + entry.count, 0);
+  const positiveEntries = entries.filter((entry) => entry.count > 0);
+  let offset = 25;
+
+  if (total === 0) {
+    return <div className="chart-empty">No ending data</div>;
+  }
+
+  return (
+    <div className="donut-layout">
+      <svg viewBox="0 0 42 42" className="donut-chart" role="img" aria-label="Ending method distribution">
+        <circle className="donut-track" cx="21" cy="21" r="15.9155" />
+        {positiveEntries.map((entry, index) => {
+          const dashOffset = offset;
+          offset -= entry.percentage;
+
+          return (
+            <circle
+              key={entry.ending}
+              className="donut-segment"
+              cx="21"
+              cy="21"
+              r="15.9155"
+              stroke={DONUT_COLORS[index % DONUT_COLORS.length]}
+              strokeDasharray={`${entry.percentage} ${100 - entry.percentage}`}
+              strokeDashoffset={dashOffset}
+            >
+              <title>{`${entry.label}: ${formatInteger(entry.count)} (${formatPercentage(entry.percentage)}%)`}</title>
+            </circle>
+          );
+        })}
+        <text x="21" y="21" textAnchor="middle" dominantBaseline="middle">
+          {formatInteger(total)}
+        </text>
+      </svg>
+      <div className="donut-legend">
+        {entries.map((entry, index) => (
+          <div key={entry.ending} className="legend-row">
+            <span style={{ background: DONUT_COLORS[index % DONUT_COLORS.length] }} />
+            <small>{entry.label}</small>
+            <strong>{formatInteger(entry.count)}</strong>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }
 
@@ -271,11 +539,61 @@ function PanelHeader({ title, value }: { readonly title: string; readonly value:
   );
 }
 
-function Metric({ label, value }: { readonly label: string; readonly value: string }) {
+function Metric({ label, value, title }: { readonly label: string; readonly value: string; readonly title?: string }) {
   return (
-    <div className="metric">
+    <div className="metric" title={title}>
       <span>{label}</span>
       <strong>{value}</strong>
+    </div>
+  );
+}
+
+function ResultMetric({
+  label,
+  result,
+  count,
+  percentage
+}: {
+  readonly label: string;
+  readonly result: "draw" | "loss" | "win";
+  readonly count: number;
+  readonly percentage: number;
+}) {
+  return (
+    <div className={`metric result-metric ${result}`}>
+      <span>{label}</span>
+      <strong>{formatInteger(count)}</strong>
+      <small>{formatPercentage(percentage)}%</small>
+    </div>
+  );
+}
+
+function SegmentedControl<TValue extends string>({
+  label,
+  values,
+  activeValue,
+  disabled,
+  onSelect
+}: {
+  readonly label: string;
+  readonly values: readonly TValue[];
+  readonly activeValue: TValue;
+  readonly disabled: boolean;
+  readonly onSelect: (value: TValue) => void;
+}) {
+  return (
+    <div className="segmented-control" role="group" aria-label={label}>
+      {values.map((value) => (
+        <button
+          key={value}
+          type="button"
+          aria-pressed={activeValue === value}
+          onClick={() => onSelect(value)}
+          disabled={disabled}
+        >
+          {value}
+        </button>
+      ))}
     </div>
   );
 }
@@ -284,57 +602,17 @@ function StackedResultBar({ results }: { readonly results: ResultBreakdown }) {
   return (
     <div className="stacked-bar" aria-label="Result percentages">
       <span className="wins" style={{ width: `${results.percentages.win}%` }} />
-      <span className="losses" style={{ width: `${results.percentages.loss}%` }} />
       <span className="draws" style={{ width: `${results.percentages.draw}%` }} />
+      <span className="losses" style={{ width: `${results.percentages.loss}%` }} />
     </div>
   );
 }
 
-function RatingSparkline({ points }: { readonly points: readonly RatingTimelinePoint[] }) {
-  const path = useMemo(() => buildPolyline(points), [points]);
-
-  return (
-    <div className="sparkline-frame">
-      {points.length === 0 ? (
-        <div className="empty-state">No data</div>
-      ) : (
-        <svg viewBox="0 0 100 42" role="img" aria-label="Rating timeline">
-          <polyline points={path} fill="none" stroke="currentColor" strokeWidth="2.5" vectorEffect="non-scaling-stroke" />
-        </svg>
-      )}
-    </div>
-  );
-}
-
-function BarRow({
-  label,
-  value,
-  percentage
-}: {
-  readonly label: string;
-  readonly value: string;
-  readonly percentage: number;
-}) {
-  return (
-    <div className="bar-row">
-      <div className="bar-meta">
-        <span>{label}</span>
-        <span>{value}</span>
-      </div>
-      <div className="single-bar">
-        <span style={{ width: `${Math.max(0, Math.min(100, percentage))}%` }} />
-      </div>
-    </div>
-  );
-}
-
-function emptyRows(labels: readonly string[]) {
-  return labels.map((label) => <BarRow key={label} label={label} value="0" percentage={0} />);
-}
-
-function buildPolyline(points: readonly RatingTimelinePoint[]): string {
+function buildRatingChartPoints(points: readonly RatingTimelinePoint[]): ChartPoint[] {
   if (points.length === 1) {
-    return "4,21 96,21";
+    const [point] = points;
+
+    return point === undefined ? [] : [{ x: 51, y: 26, point }];
   }
 
   const ratings = points.map((point) => point.rating);
@@ -342,14 +620,65 @@ function buildPolyline(points: readonly RatingTimelinePoint[]): string {
   const max = Math.max(...ratings);
   const span = Math.max(1, max - min);
 
-  return points
-    .map((point, index) => {
-      const x = 4 + (index / Math.max(1, points.length - 1)) * 92;
-      const y = 36 - ((point.rating - min) / span) * 30;
+  return points.map((point, index) => {
+    const x = 6 + (index / Math.max(1, points.length - 1)) * 90;
+    const y = 44 - ((point.rating - min) / span) * 36;
 
-      return `${round(x)},${round(y)}`;
-    })
-    .join(" ");
+    return {
+      x: round(x),
+      y: round(y),
+      point
+    };
+  });
+}
+
+function normalizeZoomRange(zoomRange: ZoomRange | null, pointCount: number): ZoomRange | null {
+  if (zoomRange === null || pointCount < 2) {
+    return null;
+  }
+
+  const start = Math.max(0, Math.min(zoomRange.start, pointCount - 1));
+  const end = Math.max(start, Math.min(zoomRange.end, pointCount - 1));
+
+  return end - start < 1 ? null : { start, end };
+}
+
+function buildBrush(start: number | null, end: number | null, pointCount: number): { x: number; width: number } | null {
+  if (start === null || end === null || pointCount < 2) {
+    return null;
+  }
+
+  const minIndex = Math.min(start, end);
+  const maxIndex = Math.max(start, end);
+  const x = 6 + (minIndex / (pointCount - 1)) * 90;
+  const width = ((maxIndex - minIndex) / (pointCount - 1)) * 90;
+
+  return {
+    x: round(x),
+    width: round(width)
+  };
+}
+
+function indexFromPointer(event: PointerEvent<SVGSVGElement>, pointCount: number): number {
+  const rect = event.currentTarget.getBoundingClientRect();
+
+  if (rect.width <= 0) {
+    return 0;
+  }
+
+  const ratio = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width));
+
+  return Math.round(ratio * (pointCount - 1));
+}
+
+function ratingRangeLabel(points: readonly RatingTimelinePoint[]): string {
+  if (points.length === 0) {
+    return "0 ELO";
+  }
+
+  const ratings = points.map((point) => point.rating);
+
+  return `${formatInteger(Math.min(...ratings))}-${formatInteger(Math.max(...ratings))} ELO`;
 }
 
 function round(value: number): number {
@@ -366,6 +695,38 @@ function statusLabel(isLoading: boolean, analysis: PlayerAnalysis | null, errorM
   }
 
   return analysis === null ? "Ready" : "Updated";
+}
+
+function formatDate(value: string | undefined): string {
+  if (value === undefined) {
+    return "";
+  }
+
+  return value.slice(0, 10);
+}
+
+function formatDuration(totalSeconds: number): string {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m ${seconds}s`;
+  }
+
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+
+  return `${seconds}s`;
+}
+
+function formatInteger(value: number): string {
+  return NUMBER_FORMAT.format(value);
+}
+
+function formatPercentage(value: number): string {
+  return value.toFixed(1);
 }
 
 function emptyResultBreakdown(): ResultBreakdown {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -6,12 +6,12 @@
   --text: #1f2623;
   --muted: #64706a;
   --border: #d9e1d7;
-  --accent: #21735f;
-  --accent-strong: #145543;
+  --win: #21735f;
+  --win-strong: #145543;
+  --loss: #b94a48;
+  --draw: #8a8377;
   --blue: #3768a6;
   --gold: #b7822d;
-  --loss: #b94a48;
-  --draw: #8a7f6a;
   --shadow: 0 18px 45px rgba(31, 38, 35, 0.08);
 }
 
@@ -52,9 +52,18 @@ button:disabled {
 }
 
 .app-shell {
-  width: min(1180px, calc(100% - 32px));
+  width: min(1220px, calc(100% - 32px));
   margin: 0 auto;
   padding: 28px 0 48px;
+}
+
+.search-band,
+.summary-panel,
+.panel {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
 }
 
 .search-band {
@@ -63,10 +72,6 @@ button:disabled {
   gap: 24px;
   align-items: end;
   padding: 24px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface);
-  box-shadow: var(--shadow);
 }
 
 .brand-block {
@@ -87,6 +92,10 @@ button:disabled {
   border-radius: 8px;
 }
 
+.board-mark span {
+  background: #e4d3b4;
+}
+
 .board-mark span:nth-child(2n),
 .board-mark span:nth-child(5),
 .board-mark span:nth-child(7),
@@ -94,18 +103,14 @@ button:disabled {
 .board-mark span:nth-child(12),
 .board-mark span:nth-child(13),
 .board-mark span:nth-child(15) {
-  background: var(--accent);
-}
-
-.board-mark span {
-  background: #e4d3b4;
+  background: var(--win);
 }
 
 .eyebrow {
   margin: 0 0 4px;
-  color: var(--accent-strong);
-  font-size: 0.86rem;
-  font-weight: 700;
+  color: var(--win-strong);
+  font-size: 0.82rem;
+  font-weight: 760;
   text-transform: uppercase;
 }
 
@@ -122,7 +127,7 @@ h1 {
 }
 
 h2 {
-  font-size: 1rem;
+  font-size: 1.08rem;
 }
 
 .search-form {
@@ -154,12 +159,13 @@ h2 {
 }
 
 .search-row input:focus {
-  border-color: var(--accent);
+  border-color: var(--win);
   box-shadow: 0 0 0 3px rgba(33, 115, 95, 0.16);
 }
 
 .search-row button,
-.segmented-control button {
+.segmented-control button,
+.text-button {
   border: 1px solid transparent;
   border-radius: 8px;
   font-weight: 720;
@@ -169,19 +175,55 @@ h2 {
   min-width: 0;
   height: 46px;
   color: #ffffff;
-  background: var(--accent);
+  background: var(--win);
 }
 
 .search-row button:hover {
-  background: var(--accent-strong);
+  background: var(--win-strong);
 }
 
-.toolbar {
-  display: flex;
-  gap: 16px;
-  align-items: center;
-  justify-content: space-between;
+.error-panel {
+  margin: 18px 0 0;
+  border: 1px solid rgba(185, 74, 72, 0.35);
+  border-radius: 8px;
+  padding: 12px 14px;
+  color: #7d2f2e;
+  background: #fff1ef;
+}
+
+.summary-panel {
+  display: grid;
+  gap: 18px;
   margin: 18px 0;
+  padding: 20px;
+}
+
+.summary-heading {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.summary-heading h2 {
+  font-size: 1.8rem;
+}
+
+.status-pill {
+  flex: 0 0 auto;
+  min-width: 116px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 8px 14px;
+  color: var(--muted);
+  text-align: center;
+  background: var(--surface-muted);
+}
+
+.summary-stats {
+  display: grid;
+  grid-template-columns: minmax(160px, 0.35fr) minmax(190px, 0.65fr);
+  gap: 12px;
 }
 
 .segmented-control {
@@ -204,26 +246,6 @@ h2 {
   background: var(--blue);
 }
 
-.status-pill {
-  flex: 0 0 auto;
-  min-width: 116px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 8px 14px;
-  color: var(--muted);
-  text-align: center;
-  background: var(--surface);
-}
-
-.error-panel {
-  margin-bottom: 18px;
-  border: 1px solid rgba(185, 74, 72, 0.35);
-  border-radius: 8px;
-  padding: 12px 14px;
-  color: #7d2f2e;
-  background: #fff1ef;
-}
-
 .dashboard-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -231,16 +253,16 @@ h2 {
 }
 
 .panel {
-  min-height: 230px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
+  min-height: 280px;
   padding: 18px;
-  background: var(--surface);
-  box-shadow: var(--shadow);
 }
 
 .wide-panel {
   grid-column: span 2;
+}
+
+.full-panel {
+  grid-column: 1 / -1;
 }
 
 .panel-header {
@@ -260,7 +282,7 @@ h2 {
 .stacked-bar {
   display: flex;
   width: 100%;
-  height: 16px;
+  height: 18px;
   overflow: hidden;
   border-radius: 999px;
   background: #dde5db;
@@ -270,23 +292,28 @@ h2 {
   min-width: 0;
 }
 
-.wins {
-  background: var(--accent);
+.wins,
+.rating-point.win {
+  background: var(--win);
+  fill: var(--win);
 }
 
-.losses {
+.losses,
+.rating-point.loss {
   background: var(--loss);
+  fill: var(--loss);
 }
 
-.draws {
+.draws,
+.rating-point.draw {
   background: var(--draw);
+  fill: var(--draw);
 }
 
 .result-metrics {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 10px;
-  margin-top: 18px;
 }
 
 .metric {
@@ -297,7 +324,8 @@ h2 {
   background: var(--surface-muted);
 }
 
-.metric span {
+.metric span,
+.metric small {
   display: block;
   color: var(--muted);
   font-size: 0.82rem;
@@ -306,104 +334,238 @@ h2 {
 .metric strong {
   display: block;
   margin-top: 4px;
-  font-size: 1.18rem;
+  font-size: 1.2rem;
+  overflow-wrap: anywhere;
 }
 
-.row-list,
-.opening-list {
+.result-metric {
+  border-top-width: 4px;
+}
+
+.result-metric.win {
+  border-top-color: var(--win);
+}
+
+.result-metric.draw {
+  border-top-color: var(--draw);
+}
+
+.result-metric.loss {
+  border-top-color: var(--loss);
+}
+
+.rating-chart-frame {
   display: grid;
-  gap: 14px;
-}
-
-.bar-row,
-.opening-row {
-  display: grid;
-  gap: 7px;
-}
-
-.bar-meta,
-.opening-meta {
-  display: flex;
   gap: 10px;
+}
+
+.rating-chart-frame svg {
+  display: block;
+  width: 100%;
+  min-height: 310px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #fbfcfa;
+  touch-action: none;
+}
+
+.chart-grid line {
+  stroke: #e5ebe2;
+  stroke-width: 0.4;
+}
+
+.rating-line {
+  stroke: var(--blue);
+  stroke-width: 1.5;
+}
+
+.rating-point {
+  stroke: #ffffff;
+  stroke-width: 0.65;
+}
+
+.zoom-brush {
+  fill: rgba(55, 104, 166, 0.14);
+  stroke: rgba(55, 104, 166, 0.38);
+  stroke-width: 0.4;
+}
+
+.chart-axis {
+  display: flex;
+  gap: 12px;
   align-items: center;
   justify-content: space-between;
   color: var(--muted);
-  font-size: 0.9rem;
+  font-size: 0.86rem;
 }
 
-.bar-meta span:first-child,
-.opening-meta span:first-child {
-  min-width: 0;
-  overflow-wrap: anywhere;
+.text-button {
+  justify-self: end;
+  height: 34px;
+  padding: 0 12px;
+  color: var(--blue);
+  background: #edf3fb;
+}
+
+.vertical-chart {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(72px, 1fr);
+  gap: 14px;
+  min-height: 300px;
+  overflow-x: auto;
+  padding: 8px 2px 2px;
+}
+
+.opening-chart {
+  margin-top: 16px;
+}
+
+.vertical-bar-item {
+  display: grid;
+  grid-template-rows: minmax(180px, 1fr) auto auto;
+  gap: 8px;
+  min-width: 72px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.vertical-bar-item strong {
   color: var(--text);
-  font-weight: 650;
+  font-size: 0.92rem;
 }
 
-.single-bar {
-  height: 9px;
+.vertical-bar-item > span {
+  min-height: 42px;
+  overflow-wrap: anywhere;
+  font-size: 0.82rem;
+}
+
+.vertical-bar-shell {
+  display: flex;
+  align-items: end;
+  justify-content: center;
+  min-height: 180px;
+  border-bottom: 1px solid var(--border);
+}
+
+.vertical-bar-stack {
+  display: flex;
+  flex-direction: column-reverse;
+  width: min(100%, 48px);
+  min-height: 2px;
   overflow: hidden;
-  border-radius: 999px;
+  border-radius: 8px 8px 0 0;
   background: #dde5db;
 }
 
-.single-bar span {
+.vertical-bar-stack span {
   display: block;
-  height: 100%;
-  border-radius: inherit;
-  background: var(--gold);
+  min-height: 0;
 }
 
-.sparkline-frame {
+.donut-layout {
   display: grid;
-  min-height: 166px;
+  grid-template-columns: minmax(112px, 0.8fr) minmax(130px, 1fr);
+  gap: 16px;
+  align-items: center;
+}
+
+.donut-chart {
+  display: block;
+  width: 100%;
+  max-width: 190px;
+  margin: 0 auto;
+}
+
+.donut-track {
+  fill: transparent;
+  stroke: #e5ebe2;
+  stroke-width: 8;
+}
+
+.donut-segment {
+  fill: transparent;
+  stroke-width: 8;
+  transform: rotate(-90deg);
+  transform-origin: center;
+}
+
+.donut-chart text {
+  fill: var(--text);
+  font-size: 0.28rem;
+  font-weight: 760;
+}
+
+.donut-legend {
+  display: grid;
+  gap: 8px;
+}
+
+.legend-row {
+  display: grid;
+  grid-template-columns: 10px minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.legend-row span {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+}
+
+.legend-row small {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-size: inherit;
+}
+
+.legend-row strong {
+  color: var(--text);
+  font-size: 0.84rem;
+}
+
+.chart-empty {
+  display: grid;
+  min-height: 220px;
   place-items: center;
   border: 1px solid var(--border);
   border-radius: 8px;
-  color: var(--blue);
-  background:
-    linear-gradient(#eef3ea 1px, transparent 1px),
-    linear-gradient(90deg, #eef3ea 1px, transparent 1px),
-    #fbfcfa;
-  background-size: 100% 33%, 20% 100%;
-}
-
-.sparkline-frame svg {
-  display: block;
-  width: 100%;
-  height: 166px;
-}
-
-.empty-state {
   color: var(--muted);
   font-weight: 650;
+  background: #fbfcfa;
 }
 
-.import-metrics {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-@media (max-width: 900px) {
+@media (max-width: 980px) {
   .search-band,
-  .dashboard-grid {
+  .dashboard-grid,
+  .summary-stats {
     grid-template-columns: 1fr;
   }
 
-  .wide-panel {
+  .wide-panel,
+  .full-panel {
     grid-column: auto;
   }
 }
 
-@media (max-width: 620px) {
+@media (max-width: 680px) {
   .app-shell {
-    width: min(100% - 20px, 1180px);
+    width: min(100% - 20px, 1220px);
     padding-top: 10px;
   }
 
-  .search-band {
+  .search-band,
+  .summary-panel,
+  .panel {
     padding: 16px;
   }
 
-  .brand-block {
+  .brand-block,
+  .summary-heading {
     align-items: flex-start;
   }
 
@@ -416,18 +578,21 @@ h2 {
     font-size: 1.55rem;
   }
 
+  .summary-heading h2 {
+    font-size: 1.45rem;
+  }
+
   .search-row,
   .result-metrics,
-  .import-metrics {
+  .donut-layout {
     grid-template-columns: 1fr;
   }
 
-  .toolbar {
-    align-items: stretch;
-    flex-direction: column;
+  .status-pill {
+    min-width: 0;
   }
 
-  .status-pill {
-    width: 100%;
+  .rating-chart-frame svg {
+    min-height: 230px;
   }
 }

--- a/apps/web/app/lib/analyze-request.test.ts
+++ b/apps/web/app/lib/analyze-request.test.ts
@@ -10,6 +10,7 @@ describe("parseAnalyzeSearchParams", () => {
         username: " TestUser ",
         timeClass: " Rapid ",
         ratingTimeClass: "BLITZ",
+        openingPlayerColor: " White ",
         openingLimit: "7",
         opponentRatingBucketSize: "200"
       })
@@ -19,6 +20,7 @@ describe("parseAnalyzeSearchParams", () => {
       username: "testuser",
       timeClass: "rapid",
       ratingTimeClass: "blitz",
+      openingPlayerColor: "white",
       openingLimit: 7,
       opponentRatingBucketSize: 200
     });
@@ -29,7 +31,8 @@ describe("parseAnalyzeSearchParams", () => {
       new URLSearchParams({
         username: "testuser",
         timeClass: " all ",
-        ratingTimeClass: "ALL"
+        ratingTimeClass: "ALL",
+        openingPlayerColor: " all "
       })
     );
 
@@ -48,6 +51,14 @@ describe("parseAnalyzeSearchParams", () => {
         })
       )
     ).toThrow(/timeClass/);
+    expect(() =>
+      parseAnalyzeSearchParams(
+        new URLSearchParams({
+          username: "testuser",
+          openingPlayerColor: "green"
+        })
+      )
+    ).toThrow(/openingPlayerColor/);
     expect(() =>
       parseAnalyzeSearchParams(
         new URLSearchParams({

--- a/apps/web/app/lib/analyze-request.test.ts
+++ b/apps/web/app/lib/analyze-request.test.ts
@@ -37,7 +37,8 @@ describe("parseAnalyzeSearchParams", () => {
     );
 
     expect(parsed).toEqual({
-      username: "testuser"
+      username: "testuser",
+      ratingTimeClass: null
     });
   });
 

--- a/apps/web/app/lib/analyze-request.ts
+++ b/apps/web/app/lib/analyze-request.ts
@@ -40,7 +40,7 @@ export function parseAnalyzeSearchParams(searchParams: URLSearchParams): ParsedA
 
   const username = normalizeUsername(rawUsername);
   const timeClass = parseTimeClass(searchParams, "timeClass");
-  const ratingTimeClass = parseTimeClass(searchParams, "ratingTimeClass");
+  const ratingTimeClass = parseRatingTimeClass(searchParams, "ratingTimeClass");
   const openingPlayerColor = parsePlayerColor(searchParams, "openingPlayerColor");
   const openingLimit = parsePositiveInteger(searchParams, "openingLimit", {
     max: 25
@@ -109,17 +109,34 @@ function normalizeUsername(rawUsername: string): string {
   }
 }
 
-function parseTimeClass(searchParams: URLSearchParams, key: "ratingTimeClass" | "timeClass"): TimeClass | undefined {
+function parseTimeClass(searchParams: URLSearchParams, key: "timeClass"): TimeClass | undefined {
   const value = searchParams.get(key);
 
   if (value === null) {
     return undefined;
   }
 
+  return parseTimeClassValue(value, key) ?? undefined;
+}
+
+function parseRatingTimeClass(
+  searchParams: URLSearchParams,
+  key: "ratingTimeClass"
+): TimeClass | null | undefined {
+  const value = searchParams.get(key);
+
+  if (value === null) {
+    return undefined;
+  }
+
+  return parseTimeClassValue(value, key);
+}
+
+function parseTimeClassValue(value: string, key: "ratingTimeClass" | "timeClass"): TimeClass | null {
   const normalizedValue = value.trim().toLowerCase();
 
   if (normalizedValue.length === 0 || normalizedValue === "all") {
-    return undefined;
+    return null;
   }
 
   if (!TIME_CLASSES.has(normalizedValue as TimeClass)) {

--- a/apps/web/app/lib/analyze-request.ts
+++ b/apps/web/app/lib/analyze-request.ts
@@ -1,9 +1,10 @@
 import type { PlayerAnalysisOptions } from "@chessinsights/analysis";
 import { ChessComApiError, normalizeChessComUsername } from "@chessinsights/chesscom-client";
 import type { ProviderErrorKind } from "@chessinsights/chesscom-client";
-import type { TimeClass } from "@chessinsights/domain";
+import type { PlayerColor, TimeClass } from "@chessinsights/domain";
 
 const TIME_CLASSES = new Set<TimeClass>(["bullet", "blitz", "rapid", "daily"]);
+const PLAYER_COLORS = new Set<PlayerColor>(["white", "black"]);
 
 export interface ParsedAnalyzeRequest extends PlayerAnalysisOptions {
   readonly username: string;
@@ -40,6 +41,7 @@ export function parseAnalyzeSearchParams(searchParams: URLSearchParams): ParsedA
   const username = normalizeUsername(rawUsername);
   const timeClass = parseTimeClass(searchParams, "timeClass");
   const ratingTimeClass = parseTimeClass(searchParams, "ratingTimeClass");
+  const openingPlayerColor = parsePlayerColor(searchParams, "openingPlayerColor");
   const openingLimit = parsePositiveInteger(searchParams, "openingLimit", {
     max: 25
   });
@@ -51,6 +53,7 @@ export function parseAnalyzeSearchParams(searchParams: URLSearchParams): ParsedA
     username,
     ...(timeClass === undefined ? {} : { timeClass }),
     ...(ratingTimeClass === undefined ? {} : { ratingTimeClass }),
+    ...(openingPlayerColor === undefined ? {} : { openingPlayerColor }),
     ...(openingLimit === undefined ? {} : { openingLimit }),
     ...(opponentRatingBucketSize === undefined ? {} : { opponentRatingBucketSize })
   };
@@ -124,6 +127,26 @@ function parseTimeClass(searchParams: URLSearchParams, key: "ratingTimeClass" | 
   }
 
   return normalizedValue as TimeClass;
+}
+
+function parsePlayerColor(searchParams: URLSearchParams, key: "openingPlayerColor"): PlayerColor | undefined {
+  const value = searchParams.get(key);
+
+  if (value === null) {
+    return undefined;
+  }
+
+  const normalizedValue = value.trim().toLowerCase();
+
+  if (normalizedValue.length === 0 || normalizedValue === "all") {
+    return undefined;
+  }
+
+  if (!PLAYER_COLORS.has(normalizedValue as PlayerColor)) {
+    throw new AnalyzeRequestError(`${key} must be white or black.`);
+  }
+
+  return normalizedValue as PlayerColor;
 }
 
 function parsePositiveInteger(

--- a/packages/analysis/src/analyze-player.test.ts
+++ b/packages/analysis/src/analyze-player.test.ts
@@ -57,8 +57,25 @@ describe("analyzeChessComPlayer", () => {
     expect(analysis.filters).toEqual({
       opponentRatingBucketSize: 100,
       openingLimit: 10,
+      openingPlayerColor: null,
       ratingTimeClass: "blitz",
       timeClass: null
+    });
+    expect(analysis.aggregates.summary).toEqual({
+      totalGames: 3,
+      results: {
+        total: 3,
+        win: 1,
+        loss: 1,
+        draw: 1,
+        percentages: {
+          win: 33.3,
+          loss: 33.3,
+          draw: 33.3
+        }
+      },
+      estimatedTimePlayedSeconds: 900,
+      skippedEstimatedTimeGames: 1
     });
     expect(analysis.aggregates.results).toMatchObject({
       total: 3,
@@ -103,6 +120,7 @@ describe("analyzeChessComPlayer", () => {
         {
           playedAt: "2024-01-15T08:26:40.000Z",
           rating: 1350,
+          result: "win",
           gameUrl: "https://www.chess.com/game/live/1001",
           timeClass: "blitz"
         }
@@ -133,6 +151,10 @@ describe("analyzeChessComPlayer", () => {
       "Queen's Pawn Opening",
       "Sicilian Defense"
     ]);
+    expect(analysis.aggregates.endingBreakdowns.wonBy.find((entry) => entry.ending === "resignation")).toMatchObject({
+      count: 1,
+      percentage: 100
+    });
   });
 
   it("supports time-class filters and explicit rating timelines", async () => {
@@ -147,6 +169,7 @@ describe("analyzeChessComPlayer", () => {
     expect(analysis.filters).toEqual({
       opponentRatingBucketSize: 100,
       openingLimit: 1,
+      openingPlayerColor: null,
       ratingTimeClass: "rapid",
       timeClass: "rapid"
     });
@@ -158,12 +181,27 @@ describe("analyzeChessComPlayer", () => {
       {
         playedAt: "2024-01-16T18:44:11.000Z",
         rating: 1402,
+        result: "loss",
         gameUrl: "https://www.chess.com/game/live/1002",
         timeClass: "rapid"
       }
     ]);
     expect(analysis.aggregates.openingSummary).toHaveLength(1);
     expect(analysis.aggregates.openingSummary[0]?.openingFamily).toBe("Italian Game");
+  });
+
+  it("supports opening color perspective filters", async () => {
+    const client = createMockClient();
+
+    const analysis = await analyzeChessComPlayer(client, "testuser", {
+      openingPlayerColor: "white"
+    });
+
+    expect(analysis.filters.openingPlayerColor).toBe("white");
+    expect(analysis.aggregates.openingSummary.map((entry) => entry.openingFamily)).toEqual([
+      "Queen's Pawn Opening",
+      "Sicilian Defense"
+    ]);
   });
 });
 

--- a/packages/analysis/src/analyze-player.test.ts
+++ b/packages/analysis/src/analyze-player.test.ts
@@ -203,6 +203,21 @@ describe("analyzeChessComPlayer", () => {
       "Sicilian Defense"
     ]);
   });
+
+  it("supports explicit all-time-class rating timelines", async () => {
+    const client = createMockClient();
+
+    const analysis = await analyzeChessComPlayer(client, "testuser", {
+      ratingTimeClass: null
+    });
+
+    expect(analysis.filters.ratingTimeClass).toBeNull();
+    expect(analysis.aggregates.ratingTimeline.points.map((point) => point.gameUrl)).toEqual([
+      "https://www.chess.com/game/live/1001",
+      "https://www.chess.com/game/live/1002",
+      "https://www.chess.com/game/daily/1003"
+    ]);
+  });
 });
 
 interface MockImportClient extends ChessComImportClient {

--- a/packages/analysis/src/analyze-player.ts
+++ b/packages/analysis/src/analyze-player.ts
@@ -1,12 +1,14 @@
 import {
+  buildEndingBreakdowns,
   buildOpeningSummary,
   buildOpponentRatingBuckets,
+  buildPlayerSummary,
   buildRatingTimeline,
   buildResultBreakdown,
   buildTimeClassBreakdown,
   getMostPlayedTimeClass
 } from "@chessinsights/analytics";
-import type { TimeClass } from "@chessinsights/domain";
+import type { PlayerColor, TimeClass } from "@chessinsights/domain";
 import { importChessComPlayer } from "@chessinsights/importer";
 import type { ChessComImportClient, ChessComImportResult } from "@chessinsights/importer";
 
@@ -17,6 +19,9 @@ const DEFAULT_OPENING_LIMIT = 10;
 const DEFAULT_OPPONENT_RATING_BUCKET_SIZE = 100;
 type TimeClassOption = {
   readonly timeClass?: TimeClass;
+};
+type PlayerColorOption = {
+  readonly playerColor?: PlayerColor;
 };
 
 export async function analyzeChessComPlayer(
@@ -53,6 +58,7 @@ export function buildPlayerAnalysis(
     filters: {
       timeClass: options.timeClass ?? null,
       ratingTimeClass,
+      openingPlayerColor: options.openingPlayerColor ?? null,
       openingLimit,
       opponentRatingBucketSize
     },
@@ -64,6 +70,7 @@ export function buildPlayerAnalysis(
       skippedArchiveUrls: importResult.skippedArchiveUrls
     },
     aggregates: {
+      summary: buildPlayerSummary(importResult.records, aggregateTimeClassOption),
       results: buildResultBreakdown(importResult.records, aggregateTimeClassOption),
       resultsByTimeClass: buildResultsByTimeClass(importResult.records),
       timeClasses: buildTimeClassBreakdown(importResult.records),
@@ -77,14 +84,20 @@ export function buildPlayerAnalysis(
       }),
       openingSummary: buildOpeningSummary(importResult.records, {
         limit: openingLimit,
+        ...toPlayerColorOption(options.openingPlayerColor),
         ...aggregateTimeClassOption
-      })
+      }),
+      endingBreakdowns: buildEndingBreakdowns(importResult.records, aggregateTimeClassOption)
     }
   };
 }
 
 function toTimeClassOption(timeClass: TimeClass | undefined): TimeClassOption {
   return timeClass === undefined ? {} : { timeClass };
+}
+
+function toPlayerColorOption(playerColor: PlayerColor | undefined): PlayerColorOption {
+  return playerColor === undefined ? {} : { playerColor };
 }
 
 function buildResultsByTimeClass(records: ChessComImportResult["records"]): ResultsByTimeClass {

--- a/packages/analysis/src/analyze-player.ts
+++ b/packages/analysis/src/analyze-player.ts
@@ -40,7 +40,7 @@ export function buildPlayerAnalysis(
   options: PlayerAnalysisOptions = {}
 ): PlayerAnalysis {
   const defaultTimeClass = getMostPlayedTimeClass(importResult.records);
-  const ratingTimeClass = options.ratingTimeClass ?? defaultTimeClass;
+  const ratingTimeClass = options.ratingTimeClass === undefined ? defaultTimeClass : options.ratingTimeClass;
   const openingLimit = options.openingLimit ?? DEFAULT_OPENING_LIMIT;
   const opponentRatingBucketSize = options.opponentRatingBucketSize ?? DEFAULT_OPPONENT_RATING_BUCKET_SIZE;
   const aggregateTimeClassOption = toTimeClassOption(options.timeClass);

--- a/packages/analysis/src/types.ts
+++ b/packages/analysis/src/types.ts
@@ -1,11 +1,13 @@
 import type {
+  EndingBreakdowns,
   OpeningSummaryEntry,
   OpponentRatingBucketsResult,
+  PlayerSummary,
   RatingTimelinePoint,
   ResultBreakdown,
   TimeClassBreakdownEntry
 } from "@chessinsights/analytics";
-import type { TimeClass } from "@chessinsights/domain";
+import type { PlayerColor, TimeClass } from "@chessinsights/domain";
 import type {
   ChessComImportResult,
   ChessComProfile,
@@ -15,6 +17,7 @@ import type {
 
 export interface PlayerAnalysisOptions extends ImportOptions {
   readonly openingLimit?: number;
+  readonly openingPlayerColor?: PlayerColor;
   readonly opponentRatingBucketSize?: number;
   readonly ratingTimeClass?: TimeClass;
   readonly timeClass?: TimeClass;
@@ -24,6 +27,7 @@ export type ResultsByTimeClass = Record<TimeClass, ResultBreakdown>;
 
 export interface PlayerAnalysisFilters {
   readonly openingLimit: number;
+  readonly openingPlayerColor: PlayerColor | null;
   readonly opponentRatingBucketSize: number;
   readonly ratingTimeClass: TimeClass | null;
   readonly timeClass: TimeClass | null;
@@ -43,11 +47,13 @@ export interface RatingTimelineAnalysis {
 }
 
 export interface PlayerAnalysisAggregates {
+  readonly endingBreakdowns: EndingBreakdowns;
   readonly openingSummary: readonly OpeningSummaryEntry[];
   readonly opponentRatingBuckets: OpponentRatingBucketsResult;
   readonly ratingTimeline: RatingTimelineAnalysis;
   readonly results: ResultBreakdown;
   readonly resultsByTimeClass: ResultsByTimeClass;
+  readonly summary: PlayerSummary;
   readonly timeClasses: readonly TimeClassBreakdownEntry[];
 }
 

--- a/packages/analysis/src/types.ts
+++ b/packages/analysis/src/types.ts
@@ -19,7 +19,7 @@ export interface PlayerAnalysisOptions extends ImportOptions {
   readonly openingLimit?: number;
   readonly openingPlayerColor?: PlayerColor;
   readonly opponentRatingBucketSize?: number;
-  readonly ratingTimeClass?: TimeClass;
+  readonly ratingTimeClass?: TimeClass | null;
   readonly timeClass?: TimeClass;
 }
 

--- a/packages/analytics/src/analytics.test.ts
+++ b/packages/analytics/src/analytics.test.ts
@@ -9,6 +9,8 @@ import { buildOpeningSummary } from "./openings.js";
 import { buildOpponentRatingBuckets } from "./opponent-buckets.js";
 import { buildRatingTimeline } from "./rating-timeline.js";
 import { buildResultBreakdown } from "./results.js";
+import { buildEndingBreakdowns } from "./endings.js";
+import { buildPlayerSummary } from "./summary.js";
 import { buildTimeClassBreakdown, getMostPlayedTimeClass } from "./time-classes.js";
 
 const fixturePath = resolve(
@@ -87,23 +89,140 @@ describe("analytics aggregations", () => {
     ]);
   });
 
+  it("builds player summary totals and estimated time played", () => {
+    expect(buildPlayerSummary(normalizedFixtureRecords())).toEqual({
+      totalGames: 3,
+      results: {
+        total: 3,
+        win: 1,
+        loss: 1,
+        draw: 1,
+        percentages: {
+          win: 33.3,
+          loss: 33.3,
+          draw: 33.3
+        }
+      },
+      estimatedTimePlayedSeconds: 900,
+      skippedEstimatedTimeGames: 1
+    });
+  });
+
+  it("groups endings by result for donut charts", () => {
+    expect(buildEndingBreakdowns(normalizedFixtureRecords())).toEqual({
+      wonBy: [
+        {
+          ending: "abandoned",
+          label: "Abandonment",
+          count: 0,
+          percentage: 0
+        },
+        {
+          ending: "checkmate",
+          label: "Checkmate",
+          count: 0,
+          percentage: 0
+        },
+        {
+          ending: "resignation",
+          label: "Resignation",
+          count: 1,
+          percentage: 100
+        },
+        {
+          ending: "timeout",
+          label: "Timeout",
+          count: 0,
+          percentage: 0
+        }
+      ],
+      lostBy: [
+        {
+          ending: "abandoned",
+          label: "Abandonment",
+          count: 0,
+          percentage: 0
+        },
+        {
+          ending: "checkmate",
+          label: "Checkmate",
+          count: 1,
+          percentage: 100
+        },
+        {
+          ending: "resignation",
+          label: "Resignation",
+          count: 0,
+          percentage: 0
+        },
+        {
+          ending: "timeout",
+          label: "Timeout",
+          count: 0,
+          percentage: 0
+        }
+      ],
+      drawnBy: [
+        {
+          ending: "agreement",
+          label: "Agreement",
+          count: 0,
+          percentage: 0
+        },
+        {
+          ending: "stalemate",
+          label: "Stalemate",
+          count: 1,
+          percentage: 100
+        },
+        {
+          ending: "repetition",
+          label: "Repetition",
+          count: 0,
+          percentage: 0
+        },
+        {
+          ending: "insufficient_material",
+          label: "Insufficient material",
+          count: 0,
+          percentage: 0
+        },
+        {
+          ending: "fifty_move",
+          label: "50-move rule",
+          count: 0,
+          percentage: 0
+        },
+        {
+          ending: "time_vs_insufficient_material",
+          label: "Time vs insufficient material",
+          count: 0,
+          percentage: 0
+        }
+      ]
+    });
+  });
+
   it("builds a rating timeline sorted by played date", () => {
     expect(buildRatingTimeline(normalizedFixtureRecords())).toEqual([
       {
         playedAt: "2024-01-15T08:26:40.000Z",
         rating: 1350,
+        result: "win",
         gameUrl: "https://www.chess.com/game/live/1001",
         timeClass: "blitz"
       },
       {
         playedAt: "2024-01-16T18:44:11.000Z",
         rating: 1402,
+        result: "loss",
         gameUrl: "https://www.chess.com/game/live/1002",
         timeClass: "rapid"
       },
       {
         playedAt: "2024-01-17T12:00:00.000Z",
         rating: 1510,
+        result: "draw",
         gameUrl: "https://www.chess.com/game/daily/1003",
         timeClass: "daily"
       }
@@ -115,6 +234,7 @@ describe("analytics aggregations", () => {
       {
         playedAt: "2024-01-15T08:26:40.000Z",
         rating: 1350,
+        result: "win",
         gameUrl: "https://www.chess.com/game/live/1001",
         timeClass: "blitz"
       }
@@ -251,8 +371,17 @@ describe("analytics aggregations", () => {
     ]);
   });
 
+  it("filters opening summaries by player color", () => {
+    expect(buildOpeningSummary(normalizedFixtureRecords(), { playerColor: "white" }).map((entry) => entry.openingFamily)).toEqual([
+      "Queen's Pawn Opening",
+      "Sicilian Defense"
+    ]);
+    expect(buildOpeningSummary(normalizedFixtureRecords(), { playerColor: "black" }).map((entry) => entry.openingFamily)).toEqual([
+      "Italian Game"
+    ]);
+  });
+
   it("rejects invalid opening summary limits", () => {
     expect(() => buildOpeningSummary(normalizedFixtureRecords(), { limit: -1 })).toThrow(TypeError);
   });
 });
-

--- a/packages/analytics/src/endings.ts
+++ b/packages/analytics/src/endings.ts
@@ -1,0 +1,73 @@
+import type { EndingCategory, NormalizedGameRecord, NormalizedResult } from "@chessinsights/domain";
+
+import { filterByTimeClass, percentage } from "./shared.js";
+import type { EndingBreakdownEntry, EndingBreakdowns, TimeClassFilter } from "./types.js";
+
+const WIN_LOSS_ENDINGS: readonly EndingCategory[] = ["abandoned", "checkmate", "resignation", "timeout"];
+const DRAW_ENDINGS: readonly EndingCategory[] = [
+  "agreement",
+  "stalemate",
+  "repetition",
+  "insufficient_material",
+  "fifty_move",
+  "time_vs_insufficient_material"
+];
+
+const ENDING_LABELS: Readonly<Record<EndingCategory, string>> = {
+  abandoned: "Abandonment",
+  agreement: "Agreement",
+  checkmate: "Checkmate",
+  fifty_move: "50-move rule",
+  insufficient_material: "Insufficient material",
+  repetition: "Repetition",
+  resignation: "Resignation",
+  stalemate: "Stalemate",
+  timeout: "Timeout",
+  time_vs_insufficient_material: "Time vs insufficient material",
+  unknown: "Unknown"
+};
+
+export function buildEndingBreakdowns(
+  records: readonly NormalizedGameRecord[],
+  options: TimeClassFilter = {}
+): EndingBreakdowns {
+  const filteredRecords = filterByTimeClass(records, options.timeClass);
+
+  return {
+    wonBy: buildEntries(filteredRecords, "win", WIN_LOSS_ENDINGS),
+    lostBy: buildEntries(filteredRecords, "loss", WIN_LOSS_ENDINGS),
+    drawnBy: buildEntries(filteredRecords, "draw", DRAW_ENDINGS)
+  };
+}
+
+function buildEntries(
+  records: readonly NormalizedGameRecord[],
+  result: NormalizedResult,
+  preferredOrder: readonly EndingCategory[]
+): EndingBreakdownEntry[] {
+  const matchingRecords = records.filter((record) => record.result === result);
+  const total = matchingRecords.length;
+  const countsByEnding = new Map<EndingCategory, number>();
+
+  for (const record of matchingRecords) {
+    countsByEnding.set(record.ending, (countsByEnding.get(record.ending) ?? 0) + 1);
+  }
+
+  const orderedEndings = [
+    ...preferredOrder,
+    ...[...countsByEnding.keys()].filter((ending) => !preferredOrder.includes(ending)).sort()
+  ];
+
+  return orderedEndings
+    .map((ending) => {
+      const count = countsByEnding.get(ending) ?? 0;
+
+      return {
+        ending,
+        label: ENDING_LABELS[ending],
+        count,
+        percentage: percentage(count, total)
+      };
+    })
+    .filter((entry) => entry.count > 0 || preferredOrder.includes(entry.ending));
+}

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,7 +1,8 @@
+export * from "./endings.js";
 export * from "./opponent-buckets.js";
 export * from "./openings.js";
 export * from "./rating-timeline.js";
 export * from "./results.js";
+export * from "./summary.js";
 export * from "./time-classes.js";
 export * from "./types.js";
-

--- a/packages/analytics/src/openings.ts
+++ b/packages/analytics/src/openings.ts
@@ -3,6 +3,7 @@ import type { NormalizedGameRecord } from "@chessinsights/domain";
 import {
   compareByCountDescThenNameAsc,
   emptyResultCounts,
+  filterByPlayerColor,
   filterByTimeClass,
   incrementResult,
   toPercentages
@@ -15,8 +16,9 @@ export function buildOpeningSummary(
 ): OpeningSummaryEntry[] {
   const limit = validateLimit(options.limit);
   const entriesByFamily = new Map<string, OpeningSummaryEntry>();
+  const recordsByTimeClass = filterByTimeClass(records, options.timeClass);
 
-  for (const record of filterByTimeClass(records, options.timeClass)) {
+  for (const record of filterByPlayerColor(recordsByTimeClass, options.playerColor)) {
     const existingEntry = entriesByFamily.get(record.openingFamily) ?? {
       openingFamily: record.openingFamily,
       counts: emptyResultCounts(),
@@ -49,4 +51,3 @@ function validateLimit(limit: number | undefined): number | undefined {
 
   return limit;
 }
-

--- a/packages/analytics/src/rating-timeline.ts
+++ b/packages/analytics/src/rating-timeline.ts
@@ -12,6 +12,7 @@ export function buildRatingTimeline(
     .map((record) => ({
       playedAt: record.playedAt as string,
       rating: record.playerRating as number,
+      result: record.result,
       gameUrl: record.gameUrl,
       timeClass: record.timeClass
     }))
@@ -27,4 +28,3 @@ function compareTimelinePoints(left: RatingTimelinePoint, right: RatingTimelineP
 
   return left.gameUrl.localeCompare(right.gameUrl);
 }
-

--- a/packages/analytics/src/shared.ts
+++ b/packages/analytics/src/shared.ts
@@ -1,4 +1,4 @@
-import type { NormalizedGameRecord, NormalizedResult, TimeClass } from "@chessinsights/domain";
+import type { NormalizedGameRecord, NormalizedResult, PlayerColor, TimeClass } from "@chessinsights/domain";
 
 import type { ResultBreakdown, ResultCounts, ResultPercentages } from "./types.js";
 
@@ -55,6 +55,17 @@ export function filterByTimeClass(
   return records.filter((record) => record.timeClass === timeClass);
 }
 
+export function filterByPlayerColor(
+  records: readonly NormalizedGameRecord[],
+  playerColor: PlayerColor | undefined
+): NormalizedGameRecord[] {
+  if (playerColor === undefined) {
+    return [...records];
+  }
+
+  return records.filter((record) => record.playerColor === playerColor);
+}
+
 export function compareByCountDescThenNameAsc(
   leftName: string,
   leftCount: number,
@@ -67,4 +78,3 @@ export function compareByCountDescThenNameAsc(
 
   return leftName.localeCompare(rightName);
 }
-

--- a/packages/analytics/src/summary.ts
+++ b/packages/analytics/src/summary.ts
@@ -1,0 +1,22 @@
+import type { NormalizedGameRecord } from "@chessinsights/domain";
+
+import { filterByTimeClass } from "./shared.js";
+import { buildResultBreakdown } from "./results.js";
+import type { PlayerSummary, TimeClassFilter } from "./types.js";
+
+export function buildPlayerSummary(
+  records: readonly NormalizedGameRecord[],
+  options: TimeClassFilter = {}
+): PlayerSummary {
+  const filteredRecords = filterByTimeClass(records, options.timeClass);
+
+  return {
+    totalGames: filteredRecords.length,
+    results: buildResultBreakdown(filteredRecords),
+    estimatedTimePlayedSeconds: filteredRecords.reduce(
+      (totalSeconds, record) => totalSeconds + (record.estimatedTimePlayedSeconds ?? 0),
+      0
+    ),
+    skippedEstimatedTimeGames: filteredRecords.filter((record) => record.estimatedTimePlayedSeconds === null).length
+  };
+}

--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -1,7 +1,11 @@
-import type { NormalizedGameRecord, TimeClass } from "@chessinsights/domain";
+import type { EndingCategory, NormalizedGameRecord, NormalizedResult, PlayerColor, TimeClass } from "@chessinsights/domain";
 
 export interface TimeClassFilter {
   readonly timeClass?: TimeClass;
+}
+
+export interface PlayerColorFilter {
+  readonly playerColor?: PlayerColor;
 }
 
 export interface ResultCounts {
@@ -30,6 +34,7 @@ export interface TimeClassBreakdownEntry {
 export interface RatingTimelinePoint {
   readonly playedAt: string;
   readonly rating: number;
+  readonly result: NormalizedResult;
   readonly gameUrl: string;
   readonly timeClass: TimeClass;
 }
@@ -59,8 +64,28 @@ export interface OpeningSummaryEntry {
   readonly percentages: ResultPercentages;
 }
 
-export interface OpeningSummaryOptions extends TimeClassFilter {
+export interface OpeningSummaryOptions extends TimeClassFilter, PlayerColorFilter {
   readonly limit?: number;
+}
+
+export interface PlayerSummary {
+  readonly totalGames: number;
+  readonly results: ResultBreakdown;
+  readonly estimatedTimePlayedSeconds: number;
+  readonly skippedEstimatedTimeGames: number;
+}
+
+export interface EndingBreakdownEntry {
+  readonly ending: EndingCategory;
+  readonly label: string;
+  readonly count: number;
+  readonly percentage: number;
+}
+
+export interface EndingBreakdowns {
+  readonly wonBy: readonly EndingBreakdownEntry[];
+  readonly lostBy: readonly EndingBreakdownEntry[];
+  readonly drawnBy: readonly EndingBreakdownEntry[];
 }
 
 export type AnalyticsInput = readonly NormalizedGameRecord[];

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -125,7 +125,9 @@ model Game {
   rawPlayerResult        String
   rawOpponentResult      String
   rawRules               String
-  rawTimeClass           String
+  rawTimeClass                String
+  rawTimeControl              String
+  estimatedTimePlayedSeconds Int?
   openingName            String
   openingFamily          String
   openingTaxonomyVersion String

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -126,7 +126,7 @@ model Game {
   rawOpponentResult      String
   rawRules               String
   rawTimeClass                String
-  rawTimeControl              String
+  rawTimeControl              String?
   estimatedTimePlayedSeconds Int?
   openingName            String
   openingFamily          String

--- a/packages/db/src/game-record.test.ts
+++ b/packages/db/src/game-record.test.ts
@@ -46,6 +46,8 @@ describe("database persistence helpers", () => {
       rawOpponentResult: "resigned",
       rawRules: "chess",
       rawTimeClass: "blitz",
+      rawTimeControl: "300",
+      estimatedTimePlayedSeconds: 300,
       openingName: "Sicilian Defense Najdorf Variation",
       openingFamily: "Sicilian Defense",
       openingTaxonomyVersion: DEFAULT_OPENING_TAXONOMY_VERSION,

--- a/packages/db/src/game-record.ts
+++ b/packages/db/src/game-record.ts
@@ -26,6 +26,8 @@ export function toGameWriteModel(input: GameWriteInput): GameWriteModel {
     rawOpponentResult: input.record.rawOpponentResult,
     rawRules: input.record.rawRules,
     rawTimeClass: input.record.rawTimeClass,
+    rawTimeControl: input.record.rawTimeControl,
+    estimatedTimePlayedSeconds: input.record.estimatedTimePlayedSeconds,
     openingName: input.record.openingName,
     openingFamily: input.record.openingFamily,
     openingTaxonomyVersion,

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -19,6 +19,7 @@ export interface AggregateFilterInput {
   readonly bucketSize?: number;
   readonly from?: string;
   readonly limit?: number;
+  readonly playerColor?: PlayerColor;
   readonly timeClass?: TimeClass;
   readonly to?: string;
 }
@@ -45,6 +46,8 @@ export interface GameWriteModel {
   readonly rawOpponentResult: string;
   readonly rawRules: string;
   readonly rawTimeClass: string;
+  readonly rawTimeControl: string;
+  readonly estimatedTimePlayedSeconds: number | null;
   readonly openingName: string;
   readonly openingFamily: string;
   readonly openingTaxonomyVersion: string;

--- a/packages/domain/src/normalize-game.test.ts
+++ b/packages/domain/src/normalize-game.test.ts
@@ -52,11 +52,13 @@ describe("normalizeChessComGame", () => {
       rawOpponentResult: "resigned",
       rawRules: "chess",
       rawTimeClass: "blitz",
+      rawTimeControl: "300",
       openingName: "Sicilian Defense Najdorf Variation",
       openingFamily: "Sicilian Defense",
       playedAt: "2024-01-15T08:26:40.000Z",
       moveCount: 5,
       plyCount: 10,
+      estimatedTimePlayedSeconds: 300,
       rated: true
     });
   });
@@ -90,6 +92,23 @@ describe("normalizeChessComGame", () => {
       rawPlayerResult: "stalemate",
       rawOpponentResult: "stalemate",
       timeClass: "daily"
+    });
+  });
+
+  it("estimates player clock time from live time controls and leaves daily controls unknown", () => {
+    const liveGame = {
+      ...fixtureGame(0),
+      time_control: "180+2"
+    };
+    const dailyGame = fixtureGame(2);
+
+    expect(normalizeChessComGame(liveGame, "testuser")).toMatchObject({
+      rawTimeControl: "180+2",
+      estimatedTimePlayedSeconds: 190
+    });
+    expect(normalizeChessComGame(dailyGame, "testuser")).toMatchObject({
+      rawTimeControl: "1/259200",
+      estimatedTimePlayedSeconds: null
     });
   });
 

--- a/packages/domain/src/normalize-game.ts
+++ b/packages/domain/src/normalize-game.ts
@@ -24,6 +24,7 @@ export function normalizeChessComGame(game: ChessComGame, username: string): Nor
   const openingName = extractOpeningName(game.pgn, game.eco);
   const plyCount = countPlyFromPgn(game.pgn);
   const moveCount = Math.ceil(plyCount / 2);
+  const rawTimeControl = game.time_control?.trim() ?? "";
 
   return {
     gameUrl: game.url,
@@ -39,11 +40,13 @@ export function normalizeChessComGame(game: ChessComGame, username: string): Nor
     rawOpponentResult: opponentResult,
     rawRules,
     rawTimeClass,
+    rawTimeControl,
     openingName,
     openingFamily: toOpeningFamily(openingName),
     playedAt: getPlayedAt(game),
     moveCount,
     plyCount,
+    estimatedTimePlayedSeconds: estimateTimePlayedSeconds(rawTimeControl, perspective.color, plyCount),
     rated: game.rated ?? null
   };
 }
@@ -104,4 +107,22 @@ function getPlayedAt(game: ChessComGame): string | null {
   }
 
   return parsedDate.toISOString();
+}
+
+function estimateTimePlayedSeconds(
+  rawTimeControl: string,
+  playerColor: PlayerColor,
+  plyCount: number
+): number | null {
+  const match = /^(\d+)(?:\+(\d+))?$/.exec(rawTimeControl);
+
+  if (match === null) {
+    return null;
+  }
+
+  const baseSeconds = Number(match[1]);
+  const incrementSeconds = match[2] === undefined ? 0 : Number(match[2]);
+  const playerMoveCount = playerColor === "white" ? Math.ceil(plyCount / 2) : Math.floor(plyCount / 2);
+
+  return baseSeconds + incrementSeconds * playerMoveCount;
 }

--- a/packages/domain/src/types.ts
+++ b/packages/domain/src/types.ts
@@ -28,6 +28,7 @@ export interface ChessComSide {
 export interface ChessComGame {
   readonly url: string;
   readonly pgn: string;
+  readonly time_control?: string;
   readonly time_class?: string;
   readonly rules?: string;
   readonly end_time?: number;
@@ -51,11 +52,12 @@ export interface NormalizedGameRecord {
   readonly rawOpponentResult: string;
   readonly rawRules: string;
   readonly rawTimeClass: string;
+  readonly rawTimeControl: string;
   readonly openingName: string;
   readonly openingFamily: string;
   readonly playedAt: string | null;
   readonly moveCount: number;
   readonly plyCount: number;
+  readonly estimatedTimePlayedSeconds: number | null;
   readonly rated: boolean | null;
 }
-


### PR DESCRIPTION
## Summary

Aligns the web dashboard with the requested player insight layout. Closes #16.

The dashboard now presents:

- Player Summary top panel with username, total games, W/D/L counts and percentages, green/gray/red stacked result bar, estimated time played, and All/Bullet/Blitz/Rapid/Daily toggles.
- ELO Over Time line chart with per-game points colored by result and game links on each point, plus drag-to-zoom and reset.
- Top Openings vertical stacked bars by win/draw/loss, with time-class filtering plus All/White/Black opening perspective.
- Result by Opponent Rating as normalized 100% stacked bars by rating bucket.
- Games Won By, Games Lost By, and Games Drawn By donut charts using normalized ending categories.

## Changed files

- `apps/web/app/components/analyze-dashboard.tsx`, `apps/web/app/globals.css`: replace the original compact panels with the target summary, ELO, opening, opponent-rating, and ending-method chart views.
- `apps/web/app/components/analyze-dashboard.test.ts`: covers stale state, time-class refetches, opening color refetches, draft-username safety, and explicit all-rating timeline requests against mocked API responses.
- `apps/web/app/lib/analyze-request.ts`, `.test.ts`: parse `openingPlayerColor` and explicit `ratingTimeClass=all` while keeping query normalization fixture-backed.
- `packages/domain/src/normalize-game.ts`, `types.ts`, tests: preserve Chess.com `time_control` and derive `estimatedTimePlayedSeconds` for live time controls.
- `packages/analytics/src/summary.ts`, `endings.ts`, existing analytics modules/tests: add player summary, ending breakdowns, opening color filters, and result-aware rating points.
- `packages/analysis/src/*`: include the new aggregates and filters in `PlayerAnalysis`, including explicit all-games rating timelines.
- `packages/db/*`: persist/map nullable `rawTimeControl` and nullable `estimatedTimePlayedSeconds` so normalized metadata can be stored without unsafe existing-row assumptions.

## Architecture / risk note

Chess.com public archive data gives us `time_control`, but not guaranteed exact elapsed clock time for every game. This PR labels the aggregate as `estimatedTimePlayedSeconds` in the data model and derives it from live time controls. Daily or non-live clock formats are counted in `skippedEstimatedTimeGames` rather than invented.

This touches normalization, analytics, analysis response shape, and Prisma schema because the requested UI requires data that was not previously exposed. Provider fetching, archive serialization, rate-limit behavior, and external API request mechanics are unchanged.

## Validation

- [x] Relevant tests run
- [x] Lint ran
- [x] Typecheck ran
- [x] Build ran for user-visible web changes
- [x] Behavior changes include regression tests
- [x] PR summary explains changed files and test results

Commands run:

```text
npm run lint
npm run typecheck
npm run test
npm run build
npm run db:validate
npm audit --audit-level=moderate
git diff --check
npm --workspace @chessinsights/web exec next start -- --port 3000
curl -sS -I http://localhost:3000/
curl -sS 'http://localhost:3000/api/analyze?username='
curl -sS http://localhost:3000/ | rg "Player Summary|ELO Over Time|Top Openings|Games Won By"
```

Commands not run / reason:

```text
Playwright E2E - not present yet in the repository.
```

Note: I accidentally ran one local `/api/analyze?username=testuser&timeClass=RAPID&openingPlayerColor=White` smoke request while checking query normalization, so one live Chess.com request happened outside the fixture-backed test suite.

## CodeRabbit follow-up

Addressed six actionable comments:

- Sent explicit `ratingTimeClass=all` from the dashboard and taught analysis to treat it as an all-games rating timeline instead of falling back to the most-played time class.
- Aligned donut legend colors with the actual positive donut segments.
- Made `rawTimeControl` nullable in Prisma to avoid unsafe existing-row migration assumptions.
- Reset rating zoom and drag state when the incoming points dataset changes.
- Kept filter refetches bound to the last analyzed username instead of the draft input value.
- Made repeated drag-to-zoom math relative to the visible slice and then translated back to full-series indices.

## Follow-up

- Add browser-level E2E once Playwright or an equivalent harness exists.
- Replace estimated time played with exact clock-duration data only if a reliable public source is added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opening-player-color filter (white/black) with re-analysis and UI control
  * Player summary panel: total games, win/draw/loss counts & percentages, estimated time played
  * Ending-method breakdowns with three donut charts and legends
  * Interactive rating chart: drag-to-zoom, brush, tooltips, and reset; redesigned dashboard layout and time-class controls

* **Style**
  * Updated theme tokens and styling for win/loss/draw states and charts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
